### PR TITLE
fix: resolve 400 on list-organization-memberships

### DIFF
--- a/calendly
+++ b/calendly
@@ -703,11 +703,17 @@ program
 				throw new Error('CALENDLY_API_KEY environment variable is required');
 			}
 
+			const args = cmdOpts.raw ? JSON.parse(cmdOpts.raw) : ({} as Record<string, unknown>);
+			const userUri = cmdOpts.userUri ?? args.user_uri;
+			const organizationUri = cmdOpts.organizationUri ?? args.organization_uri;
+			const email = cmdOpts.email ?? args.email;
+			const count = cmdOpts.count ?? args.count;
+
 			const urlParams = new URLSearchParams();
-			if (cmdOpts.userUri) urlParams.append('user', cmdOpts.userUri);
-			if (cmdOpts.organizationUri) urlParams.append('organization', cmdOpts.organizationUri);
-			if (cmdOpts.email) urlParams.append('email', cmdOpts.email);
-			if (cmdOpts.count) urlParams.append('count', cmdOpts.count.toString());
+			if (userUri) urlParams.append('user', String(userUri));
+			if (organizationUri) urlParams.append('organization', String(organizationUri));
+			if (email) urlParams.append('email', String(email));
+			if (count !== undefined) urlParams.append('count', String(count));
 
 			const response = await axios.get(
 				`https://api.calendly.com/organization_memberships?${urlParams.toString()}`,
@@ -720,7 +726,7 @@ program
 				}
 			);
 
-			printResult(createCallResult(response.data), globalOptions.output ?? 'text');
+			printResult(response.data, globalOptions.output ?? 'text');
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			console.error(`Error: ${message}`);


### PR DESCRIPTION
## Summary\n- bypass the MCP wrapper for  and call Calendly REST API directly\n- send documented query params (, , , )\n- preserve CLI output behavior via  formatting\n\n## Verification\n- Usage: list-organization-memberships [--user-uri <user-uri>] [--organization-uri <organization-uri>] [--email <email>] [--count <count:number>] [--raw <json>]

List organization memberships for the authenticated user

Options:
  --raw <json>                           Provide raw JSON arguments to the tool, bypassing flag parsing.
  --user-uri <user-uri>                  URI of the user
  --organization-uri <organization-uri>  URI of the organization
  --email <email>                        Filter by email
  --count <count:number>                 Number of memberships to return (default 20, max 100) (example: 1)
  -h, --help                             display help for command

Example:
  mcporter call calendly.list_organization_memberships(count: 1)\n\nCloses #13