### PR TITLE
feat(cli): add cross-calendar search-team

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,15 @@ This command fetches events **and** invitee details in a single API call using C
 
 Supports pagination with `--page-size` and `--max-pages` for large orgs.
 
+### Search Team Calendars by Invitee Email
+
+```bash
+./calendly search-team --email "person@example.com" --organization-uri "<YOUR_ORG_URI>" --count 25 --max-membership-pages 10
+```
+
+This command resolves team members from organization memberships, scans each member's events in bounded pages, and returns matching events with member context.
+`--max-membership-pages` defaults to `10`; if more data exists than the configured scan limits allow, output meta includes `has_more: true` and a `truncation_reason`.
+
 ### Get Event Details
 
 ```bash
@@ -83,6 +92,7 @@ Supports pagination with `--page-size` and `--max-pages` for large orgs.
 - `cancel-event` - Cancel an event
 - `list-event-invitees` - List invitees for a specific event
 - `search-invitees` - Search events by invitee email across paginated results
+- `search-team` - Search invitee email across team member calendars
 - `list-organization-memberships` - List organization memberships
 
 ### OAuth

--- a/calendly
+++ b/calendly
@@ -5,6 +5,7 @@ import { createRuntime, createServerProxy } from 'mcporter';
 import { createCallResult } from 'mcporter';
 import axios from 'axios';
 import { buildOrganizationMembershipParams } from './src/organization-memberships';
+import { filterInviteesByEmail, getCountPageWindow, getTeamSearchTruncationReason, normalizeTeamSearchOptions, toTeamMemberContext } from './search-team-helpers';
 
 const embeddedServer = {
   "name": "calendly",
@@ -243,6 +244,12 @@ const generatorTools = [
     "flags": "--email <email> [--user-uri <user-uri>] [--organization-uri <organization-uri>] [--status <status:active|canceled>] [--min-start-time <min-start-time:iso-8601>] [--max-start-time <max-start-time:iso-8601>] [--page-size <page-size:number>] [--max-pages <max-pages:number>]"
   },
   {
+    "name": "search-team",
+    "description": "Search invitee email across team members by scanning organization memberships and member events",
+    "usage": "search-team --email <email> [--min-start-time <min-start-time:iso-8601>] [--max-start-time <max-start-time:iso-8601>] [--status <status:active|canceled>] [--organization-uri <organization-uri>] [--count <count:number>] [--max-membership-pages <max-membership-pages:number>]",
+    "flags": "--email <email> [--min-start-time <min-start-time:iso-8601>] [--max-start-time <max-start-time:iso-8601>] [--status <status:active|canceled>] [--organization-uri <organization-uri>] [--count <count:number>] [--max-membership-pages <max-membership-pages:number>]"
+  },
+  {
     "name": "get-event",
     "description": "Get details of a specific event",
     "usage": "get-event --event-uuid <event-uuid> [--raw <json>]",
@@ -325,6 +332,7 @@ const commandSignatures: Record<string, string> = {
   "list-events": "function list_events(user_uri?: string, organization_uri?: string, status?: \"active\" | \"canceled\", max_start_time?: string, min_start_time?: string);",
   "list-events-with-invitees": "function list_events_with_invitees(user_uri?: string, organization_uri?: string, status?: \"active\" | \"canceled\", max_start_time?: string, min_start_time?: string, count?: number);",
   "search-invitees": "function search_invitees(email: string, user_uri?: string, organization_uri?: string, status?: \"active\" | \"canceled\", min_start_time?: string, max_start_time?: string, page_size?: number, max_pages?: number);",
+  "search-team": "function search_team(email: string, min_start_time?: string, max_start_time?: string, status?: \"active\" | \"canceled\", organization_uri?: string, count?: number, max_membership_pages?: number);",
   "get-event": "function get_event(event_uuid: string);",
   "list-event-invitees": "function list_event_invitees(event_uuid: string, status?: \"active\" | \"canceled\", email?: string, count?: number);",
   "cancel-event": "function cancel_event(event_uuid: string, reason?: string);",
@@ -706,6 +714,169 @@ program
 		}
 	})
 	.addHelpText('after', () => '\nExample:\n  ' + "./calendly search-invitees --email person@example.com --organization-uri <ORG_URI>");
+
+program
+	.command("search-team")
+	.summary("search-team --email <email> [--min-start-time <min-start-time:iso-8601>] [--max-start-time <max-start-time:iso-8601>] [--status <status:active|canceled>] [--organization-uri <organization-uri>] [--count <count:number>] [--max-membership-pages <max-membership-pages:number>]")
+	.description("Search invitee email across team members by scanning organization memberships and member events")
+	.usage("--email <email> [--min-start-time <min-start-time:iso-8601>] [--max-start-time <max-start-time:iso-8601>] [--status <status:active|canceled>] [--organization-uri <organization-uri>] [--count <count:number>] [--max-membership-pages <max-membership-pages:number>] [--raw <json>]")
+	.option('--raw <json>', 'Provide raw JSON arguments to the tool, bypassing flag parsing.')
+	.option("--email <email>", "Invitee email to search for")
+	.option("--min-start-time <min-start-time:iso-8601>", "Minimum start time for events (ISO 8601 format)")
+	.option("--max-start-time <max-start-time:iso-8601>", "Maximum start time for events (ISO 8601 format)")
+	.option("--status <status:active|canceled>", "Filter events by status (choices: active, canceled; example: active)")
+	.option("--organization-uri <organization-uri>", "Optional organization URI scope")
+	.option("--count <count:number>", "Maximum number of matching events to return (default 20, max 100)", (value) => parseInt(value, 10))
+	.option("--max-membership-pages <max-membership-pages:number>", "Maximum organization membership pages to scan (default 10); results can be truncated when more pages exist", (value) => parseInt(value, 10))
+	.action(async (cmdOpts) => {
+		const globalOptions = program.opts();
+		try {
+			const apiKey = process.env.CALENDLY_API_KEY;
+			if (!apiKey) throw new Error('CALENDLY_API_KEY environment variable is required');
+
+			const rawArgs = cmdOpts.raw ? JSON.parse(cmdOpts.raw) : ({} as Record<string, unknown>);
+			const query = normalizeTeamSearchOptions(cmdOpts as Record<string, unknown>, rawArgs);
+			const timeout = globalOptions.timeout || 30000;
+			const memberships: any[] = [];
+			let membershipPageToken: string | undefined;
+			let membershipPagesScanned = 0;
+			let membershipPageLimitReached = false;
+
+			do {
+				const membershipParams = new URLSearchParams();
+				membershipParams.append('count', '100');
+				if (query.organization_uri) membershipParams.append('organization', query.organization_uri);
+				if (membershipPageToken) membershipParams.append('page_token', membershipPageToken);
+
+				const membershipResponse = await axios.get(
+					`https://api.calendly.com/organization_memberships?${membershipParams.toString()}`,
+					{
+						headers: {
+							'Authorization': `Bearer ${apiKey}`,
+							'Content-Type': 'application/json',
+						},
+						timeout,
+					}
+				);
+
+				const pageMemberships = Array.isArray(membershipResponse.data?.collection) ? membershipResponse.data.collection : [];
+				memberships.push(...pageMemberships);
+				membershipPageToken = membershipResponse.data?.pagination?.next_page_token;
+				membershipPagesScanned += 1;
+			} while (membershipPageToken && membershipPagesScanned < query.max_membership_pages);
+
+			if (Boolean(membershipPageToken) && membershipPagesScanned >= query.max_membership_pages) {
+				membershipPageLimitReached = true;
+			}
+
+			const members = memberships.filter((membership) => typeof membership?.user === 'string' && membership.user.length > 0);
+			const seenMemberUris = new Set<string>();
+			const uniqueMembers = members.filter((membership) => {
+				const userUri = String(membership.user);
+				if (seenMemberUris.has(userUri)) return false;
+				seenMemberUris.add(userUri);
+				return true;
+			});
+
+			const matches: any[] = [];
+			const { pageSize, maxPages } = getCountPageWindow(query.count);
+			let membersScanned = 0;
+			let eventPagesScanned = 0;
+			let eventsScanned = 0;
+			let reachedResultCap = false;
+			let memberEventPageLimitReached = false;
+
+			for (const membership of uniqueMembers) {
+				if (matches.length >= query.count) {
+					reachedResultCap = true;
+					break;
+				}
+				membersScanned += 1;
+				let pageToken: string | undefined;
+				let memberPages = 0;
+				let memberEventsScanned = 0;
+				const memberEventScanLimit = pageSize * maxPages;
+
+				while (memberPages < maxPages && memberEventsScanned < memberEventScanLimit) {
+					const eventParams = new URLSearchParams();
+					eventParams.append('count', pageSize.toString());
+					eventParams.append('expand', 'invitees');
+					eventParams.append('user', String(membership.user));
+					if (query.organization_uri) eventParams.append('organization', query.organization_uri);
+					if (query.status) eventParams.append('status', query.status);
+					if (query.min_start_time) eventParams.append('min_start_time', query.min_start_time);
+					if (query.max_start_time) eventParams.append('max_start_time', query.max_start_time);
+					if (pageToken) eventParams.append('page_token', pageToken);
+
+					const eventsResponse = await axios.get(
+						`https://api.calendly.com/scheduled_events?${eventParams.toString()}`,
+						{
+							headers: {
+								'Authorization': `Bearer ${apiKey}`,
+								'Content-Type': 'application/json',
+							},
+							timeout,
+						}
+					);
+
+					const events = Array.isArray(eventsResponse.data?.collection) ? eventsResponse.data.collection : [];
+					memberPages += 1;
+					eventPagesScanned += 1;
+					memberEventsScanned += events.length;
+					eventsScanned += events.length;
+
+					for (const event of events) {
+						const matchingInvitees = filterInviteesByEmail(event?.invitees, query.email);
+						if (matchingInvitees.length > 0) {
+							matches.push({
+								member: toTeamMemberContext(membership),
+								event,
+								matching_invitees: matchingInvitees,
+							});
+							if (matches.length >= query.count) {
+								reachedResultCap = true;
+								break;
+							}
+						}
+					}
+					if (reachedResultCap) break;
+
+					pageToken = eventsResponse.data?.pagination?.next_page_token;
+					if (!pageToken) break;
+				}
+
+				if (Boolean(pageToken) && memberPages >= maxPages) {
+					memberEventPageLimitReached = true;
+				}
+			}
+
+			const truncationReason = getTeamSearchTruncationReason({
+				membershipPageLimitReached,
+				memberEventPageLimitReached,
+				resultCapReached: reachedResultCap,
+			});
+
+			printResult({
+				query,
+				meta: {
+					memberships_scanned: memberships.length,
+					members_scanned: membersScanned,
+					membership_pages_scanned: membershipPagesScanned,
+					event_pages_scanned: eventPagesScanned,
+					events_scanned: eventsScanned,
+					matches: matches.length,
+					has_more: Boolean(truncationReason),
+					...(truncationReason ? { truncation_reason: truncationReason } : {}),
+				},
+				collection: matches.slice(0, query.count),
+			}, globalOptions.output ?? 'text');
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			console.error(`Error: ${message}`);
+			process.exit(1);
+		}
+	})
+	.addHelpText('after', () => '\nExample:\n  ' + "./calendly search-team --email person@example.com --organization-uri <ORG_URI> --count 25");
 
 program
 	.command("get-event")

--- a/calendly.test.ts
+++ b/calendly.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "bun:test";
+import { filterInviteesByEmail, getCountPageWindow, getTeamSearchTruncationReason, normalizeTeamSearchOptions } from "./search-team-helpers";
+
+describe('normalizeTeamSearchOptions', () => {
+	test('throws when email is missing', () => {
+		expect(() => normalizeTeamSearchOptions({}, {})).toThrow('email is required');
+	});
+
+	test('normalizes email and clamps count', () => {
+		const options = normalizeTeamSearchOptions(
+			{ email: ' Person@Example.com ', count: 999, status: 'active' },
+			{}
+		);
+		expect(options.email).toBe('person@example.com');
+		expect(options.count).toBe(100);
+		expect(options.max_membership_pages).toBe(10);
+		expect(options.status).toBe('active');
+	});
+
+	test('uses raw args fallback and preserves optional filters', () => {
+		const options = normalizeTeamSearchOptions(
+			{},
+			{
+				email: 'person@example.com',
+				min_start_time: '2026-01-01T00:00:00Z',
+				max_start_time: '2026-12-31T23:59:59Z',
+				organization_uri: 'https://api.calendly.com/organizations/ORG',
+				count: 12,
+				max_membership_pages: 3,
+			}
+		);
+		expect(options.email).toBe('person@example.com');
+		expect(options.min_start_time).toBe('2026-01-01T00:00:00Z');
+		expect(options.max_start_time).toBe('2026-12-31T23:59:59Z');
+		expect(options.organization_uri).toBe('https://api.calendly.com/organizations/ORG');
+		expect(options.count).toBe(12);
+		expect(options.max_membership_pages).toBe(3);
+	});
+
+	test('rejects invalid status and non-numeric count', () => {
+		expect(() => normalizeTeamSearchOptions(
+			{ email: 'person@example.com', status: 'pending' },
+			{}
+		)).toThrow('status must be either "active" or "canceled"');
+
+		expect(() => normalizeTeamSearchOptions(
+			{ email: 'person@example.com', count: 'wat' },
+			{}
+		)).toThrow('count must be a valid number');
+
+		expect(() => normalizeTeamSearchOptions(
+			{ email: 'person@example.com', maxMembershipPages: 'wat' },
+			{}
+		)).toThrow('max_membership_pages must be a valid number');
+	});
+
+	test('clamps max membership pages to at least one', () => {
+		const options = normalizeTeamSearchOptions(
+			{ email: 'person@example.com', maxMembershipPages: 0 },
+			{}
+		);
+		expect(options.max_membership_pages).toBe(1);
+	});
+});
+
+describe('filterInviteesByEmail', () => {
+	test('returns case-insensitive invitee matches only', () => {
+		const matches = filterInviteesByEmail(
+			[
+				{ email: 'PERSON@example.com', name: 'Person' },
+				{ email: 'other@example.com', name: 'Other' },
+				{ name: 'No Email' },
+				null,
+			],
+			'person@example.com'
+		);
+		expect(matches.length).toBe(1);
+		expect(matches[0].email).toBe('PERSON@example.com');
+	});
+
+	test('handles non-array invitees', () => {
+		expect(filterInviteesByEmail(undefined, 'person@example.com')).toEqual([]);
+		expect(filterInviteesByEmail({}, 'person@example.com')).toEqual([]);
+	});
+});
+
+describe('getCountPageWindow', () => {
+	test('returns bounded multi-page scan window', () => {
+		expect(getCountPageWindow(1)).toEqual({ pageSize: 20, maxPages: 5 });
+		expect(getCountPageWindow(25)).toEqual({ pageSize: 25, maxPages: 5 });
+		expect(getCountPageWindow(100)).toEqual({ pageSize: 100, maxPages: 5 });
+	});
+});
+
+describe('getTeamSearchTruncationReason', () => {
+	test('returns undefined when no truncation happened', () => {
+		expect(getTeamSearchTruncationReason({
+			membershipPageLimitReached: false,
+			memberEventPageLimitReached: false,
+			resultCapReached: false,
+		})).toBeUndefined();
+	});
+
+	test('prioritizes membership limit, then member event limit, then result cap', () => {
+		expect(getTeamSearchTruncationReason({
+			membershipPageLimitReached: true,
+			memberEventPageLimitReached: true,
+			resultCapReached: true,
+		})).toBe('membership_page_limit');
+
+		expect(getTeamSearchTruncationReason({
+			membershipPageLimitReached: false,
+			memberEventPageLimitReached: true,
+			resultCapReached: true,
+		})).toBe('member_event_page_limit');
+
+		expect(getTeamSearchTruncationReason({
+			membershipPageLimitReached: false,
+			memberEventPageLimitReached: false,
+			resultCapReached: true,
+		})).toBe('result_cap');
+	});
+});

--- a/search-team-helpers.ts
+++ b/search-team-helpers.ts
@@ -1,0 +1,87 @@
+export type TeamSearchOptions = {
+	email: string;
+	min_start_time?: string;
+	max_start_time?: string;
+	status?: 'active' | 'canceled';
+	organization_uri?: string;
+	count: number;
+	max_membership_pages: number;
+};
+
+export type TeamSearchTruncationReason = 'membership_page_limit' | 'member_event_page_limit' | 'result_cap';
+
+export type TeamMemberContext = {
+	membership_uri?: string;
+	user_uri?: string;
+	user_email?: string;
+	user_name?: string;
+	organization_uri?: string;
+};
+
+export function normalizeTeamSearchOptions(cmdOpts: Record<string, unknown>, rawArgs: Record<string, unknown>): TeamSearchOptions {
+	const emailInput = cmdOpts.email ?? rawArgs.email;
+	if (!emailInput || typeof emailInput !== 'string' || emailInput.trim().length === 0) {
+		throw new Error('email is required (use --email or --raw {"email":"..."})');
+	}
+
+	const countInput = Number(cmdOpts.count ?? rawArgs.count ?? 20);
+	if (!Number.isFinite(countInput)) {
+		throw new Error('count must be a valid number');
+	}
+	const count = Math.max(1, Math.min(100, Math.trunc(countInput)));
+
+	const maxMembershipPagesInput = Number(cmdOpts.maxMembershipPages ?? rawArgs.max_membership_pages ?? 10);
+	if (!Number.isFinite(maxMembershipPagesInput)) {
+		throw new Error('max_membership_pages must be a valid number');
+	}
+	const max_membership_pages = Math.max(1, Math.trunc(maxMembershipPagesInput));
+
+	const statusInput = cmdOpts.status ?? rawArgs.status;
+	if (statusInput !== undefined && statusInput !== 'active' && statusInput !== 'canceled') {
+		throw new Error('status must be either "active" or "canceled"');
+	}
+
+	return {
+		email: emailInput.trim().toLowerCase(),
+		min_start_time: (cmdOpts.minStartTime ?? rawArgs.min_start_time) as string | undefined,
+		max_start_time: (cmdOpts.maxStartTime ?? rawArgs.max_start_time) as string | undefined,
+		status: statusInput as 'active' | 'canceled' | undefined,
+		organization_uri: (cmdOpts.organizationUri ?? rawArgs.organization_uri) as string | undefined,
+		count,
+		max_membership_pages,
+	};
+}
+
+export function filterInviteesByEmail(invitees: unknown, normalizedEmail: string): any[] {
+	if (!Array.isArray(invitees)) return [];
+	return invitees.filter((invitee: any) => {
+		return typeof invitee?.email === 'string' && invitee.email.toLowerCase() === normalizedEmail;
+	});
+}
+
+export function toTeamMemberContext(membership: any): TeamMemberContext {
+	return {
+		membership_uri: membership?.uri,
+		user_uri: membership?.user,
+		user_email: membership?.user_email,
+		user_name: membership?.user_name,
+		organization_uri: membership?.organization,
+	};
+}
+
+export function getCountPageWindow(totalCount: number): { pageSize: number; maxPages: number } {
+	const pageSize = Math.max(1, Math.min(100, Math.max(20, totalCount)));
+	const maxPages = 5;
+	return { pageSize, maxPages };
+}
+
+export function getTeamSearchTruncationReason(flags: {
+	membershipPageLimitReached: boolean;
+	memberEventPageLimitReached: boolean;
+	resultCapReached: boolean;
+}): TeamSearchTruncationReason | undefined {
+	if (flags.membershipPageLimitReached) return 'membership_page_limit';
+	if (flags.memberEventPageLimitReached) return 'member_event_page_limit';
+	if (flags.resultCapReached) return 'result_cap';
+	return undefined;
+}


### PR DESCRIPTION
## What
- add new `search-team` command to scan team calendars for an invitee email
- resolve members from `organization_memberships`, dedupe by user URI, and scan each member's events with bounded pagination
- filter invitees by normalized email and return consolidated matches with member context + scan metadata
- add helper module for option normalization, invitee filtering, and bounded page-window logic
- add unit tests for normalization/validation and filtering helpers
- document the new command in README examples and command list

## Why
- issue #14 requests cross-calendar team search in one command instead of manual per-user queries
- this unlocks the intended workflow after fixing memberships API usage

## Tests
- `bun test`
- `./calendly search-team --help`

## AI Assistance
- AI-assisted: yes (Codex CLI)
- Testing level: lightly tested (unit tests + CLI help smoke)
- Prompt/session log: codex --yolo exec on branch feat/issue-14-search-team-command
- I understand this code: yes

Closes #14
