### PR TITLE
feat(cli): expand list-events invitee workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,11 @@ Get your token from: https://calendly.com/integrations/api_webhooks
 ### List Events with Invitees (Single Call)
 
 ```bash
-./calendly list-events-with-invitees --status active
+./calendly list-events --status active --include-invitees
 ```
 
 This command fetches events **and** invitee details in a single API call using Calendly's `expand=invitees` parameter, reducing API calls from 5+ to 1.
+Backward-compatible alias still works: `./calendly list-events-with-invitees --status active`.
 
 ### Search Invitees by Email
 
@@ -122,8 +123,8 @@ Signing secret handling guidance:
 ### Event Management
 
 - `get-current-user` - Get authenticated user details
-- `list-events` - List scheduled events
-- `list-events-with-invitees` - List events with invitee details (single API call)
+- `list-events` - List scheduled events (`--include-invitees` for single-call invitee details)
+- `list-events-with-invitees` - Compatibility alias for single-call invitee details
 - `get-event` - Get event details
 - `cancel-event` - Cancel an event
 - `list-event-invitees` - List invitees for a specific event

--- a/SKILL.md
+++ b/SKILL.md
@@ -31,8 +31,8 @@ calendly cancel-event --event-uuid <UUID> --reason "Rescheduling needed"
 - `get-current-user` - Get authenticated user details
 
 ### Events
-- `list-events` - List scheduled events (requires --user-uri)
-- `list-events-with-invitees` - List events with invitee details in a single API call
+- `list-events` - List scheduled events (requires --user-uri); add `--include-invitees` for one-call invitee details
+- `list-events-with-invitees` - Compatibility alias for one-call invitee details
 - `get-event` - Get event details (requires --event-uuid)
 - `cancel-event` - Cancel an event (requires --event-uuid, optional --reason)
 
@@ -63,9 +63,9 @@ Get your Personal Access Token from: https://calendly.com/integrations/api_webho
 
 When user asks about:
 - "What meetings do I have?" → `list-events` with `--min-start-time` (use recent date!)
-- "Show me all demos this week with who booked them" → `list-events-with-invitees` (single call!)
+- "Show me all demos this week with who booked them" → `list-events --include-invitees` (single call!)
 - "Cancel my 2pm meeting" → Find with `list-events` (time-filtered), then `cancel-event`
-- "Who's attending X meeting?" → `list-events-with-invitees` or `list-event-invitees`
+- "Who's attending X meeting?" → `list-events --include-invitees` or `list-event-invitees`
 
 **Note:** First time, run `calendly get-current-user` to obtain your User URI.
 
@@ -90,8 +90,9 @@ calendly list-events \
   -o json | jq .
 
 # List events with invitees in single API call (recommended for "who booked?")
-calendly list-events-with-invitees \
+calendly list-events \
   --user-uri "<YOUR_USER_URI>" \
+  --include-invitees \
   --status active
 
 # Get event details
@@ -168,15 +169,16 @@ MCPORTER_CONFIG=./mcporter.json npx mcporter@latest generate-cli --server calend
 
 The API returns events oldest-first by default and doesn't support pagination via CLI. Without a time filter, you'll get events from years ago.
 
-For getting invitees with events, use `list-events-with-invitees` for a single API call instead of multiple calls.
+For getting invitees with events, use `list-events --include-invitees` for a single API call instead of multiple calls.
 
 ```bash
 # Last 7 days
 calendly list-events --user-uri "<URI>" --min-start-time "$(date -u -d '7 days ago' +%Y-%m-%dT00:00:00Z)"
 
 # This week with invitees (single call)
-calendly list-events-with-invitees \
+calendly list-events \
   --user-uri "<URI>" \
+  --include-invitees \
   --min-start-time "2026-01-20T00:00:00Z" \
   --max-start-time "2026-01-27T23:59:59Z"
 

--- a/calendly
+++ b/calendly
@@ -6,6 +6,7 @@ import { createCallResult } from 'mcporter';
 import axios from 'axios';
 import { buildOrganizationMembershipParams } from './src/organization-memberships';
 import { filterInviteesByEmail, getCountPageWindow, getTeamSearchTruncationReason, normalizeTeamSearchOptions, toTeamMemberContext } from './search-team-helpers';
+import { eventInviteeCount, extractInviteePaginationMeta, normalizeInvitees, shouldIncludeInvitees, toCalendlyScheduledEventsParams } from './src/list-events-invitees';
 
 const embeddedServer = {
   "name": "calendly",
@@ -227,15 +228,15 @@ const generatorTools = [
   },
   {
     "name": "list-events",
-    "description": "List scheduled events for the authenticated user",
-    "usage": "list-events [--user-uri <user-uri>] [--organization-uri <organization-uri>] [--status <status:active|canceled>] [--max-start-time <max-start-time:iso-8601>] [--min-start-time <min-start-time:iso-8601>] [--raw <json>]",
-    "flags": "[--user-uri <user-uri>] [--organization-uri <organization-uri>] [--status <status:active|canceled>] [--max-start-time <max-start-time:iso-8601>] [--min-start-time <min-start-time:iso-8601>] [--raw <json>]"
+    "description": "List scheduled events; optionally include invitee details in one API call",
+    "usage": "list-events [--user-uri <user-uri>] [--organization-uri <organization-uri>] [--status <status:active|canceled>] [--max-start-time <max-start-time:iso-8601>] [--min-start-time <min-start-time:iso-8601>] [--include-invitees] [--expand <expand:invitees>] [--raw <json>]",
+    "flags": "[--user-uri <user-uri>] [--organization-uri <organization-uri>] [--status <status:active|canceled>] [--max-start-time <max-start-time:iso-8601>] [--min-start-time <min-start-time:iso-8601>] [--include-invitees] [--expand <expand:invitees>] [--raw <json>]"
   },
   {
     "name": "list-events-with-invitees",
-    "description": "List scheduled events with invitee details in a single API call using Calendly's expand=invitees parameter",
-    "usage": "list-events-with-invitees [--user-uri <user-uri>] [--organization-uri <organization-uri>] [--status <status:active|canceled>] [--max-start-time <max-start-time:iso-8601>] [--min-start-time <min-start-time:iso-8601>] [--count <count:number>]",
-    "flags": "[--user-uri <user-uri>] [--organization-uri <organization-uri>] [--status <status:active|canceled>] [--max-start-time <max-start-time:iso-8601>] [--min-start-time <min-start-time:iso-8601>] [--count <count:number>]"
+    "description": "Compatibility command for listing events with invitee details in one API call",
+    "usage": "list-events-with-invitees [--user-uri <user-uri>] [--organization-uri <organization-uri>] [--status <status:active|canceled>] [--max-start-time <max-start-time:iso-8601>] [--min-start-time <min-start-time:iso-8601>] [--count <count:number>] [--raw <json>]",
+    "flags": "[--user-uri <user-uri>] [--organization-uri <organization-uri>] [--status <status:active|canceled>] [--max-start-time <max-start-time:iso-8601>] [--min-start-time <min-start-time:iso-8601>] [--count <count:number>] [--raw <json>]"
   },
   {
     "name": "search-invitees",
@@ -353,7 +354,7 @@ const commandSignatures: Record<string, string> = {
   "exchange-code-for-tokens": "function exchange_code_for_tokens(code: string, redirect_uri: string);",
   "refresh-access-token": "function refresh_access_token(refresh_token: string);",
   "get-current-user": "function get_current_user();",
-  "list-events": "function list_events(user_uri?: string, organization_uri?: string, status?: \"active\" | \"canceled\", max_start_time?: string, min_start_time?: string);",
+  "list-events": "function list_events(user_uri?: string, organization_uri?: string, status?: \"active\" | \"canceled\", max_start_time?: string, min_start_time?: string, include_invitees?: boolean, expand?: string, count?: number);",
   "list-events-with-invitees": "function list_events_with_invitees(user_uri?: string, organization_uri?: string, status?: \"active\" | \"canceled\", max_start_time?: string, min_start_time?: string, count?: number);",
   "search-invitees": "function search_invitees(email: string, user_uri?: string, organization_uri?: string, status?: \"active\" | \"canceled\", min_start_time?: string, max_start_time?: string, page_size?: number, max_pages?: number);",
   "search-team": "function search_team(email: string, min_start_time?: string, max_start_time?: string, status?: \"active\" | \"canceled\", organization_uri?: string, count?: number, max_membership_pages?: number);",
@@ -369,6 +370,115 @@ program.configureHelp({
 	},
 });
 program.showSuggestionAfterError(true);
+
+type ListEventsCmdOptions = {
+	raw?: string;
+	userUri?: string;
+	organizationUri?: string;
+	status?: 'active' | 'canceled';
+	maxStartTime?: string;
+	minStartTime?: string;
+	count?: number;
+	includeInvitees?: boolean;
+	expand?: string;
+};
+
+function normalizeListEventsQuery(cmdOpts: ListEventsCmdOptions, defaults: Record<string, unknown> = {}): Record<string, unknown> {
+	const query: Record<string, unknown> = { ...defaults };
+	if (cmdOpts.userUri !== undefined) query.user_uri = cmdOpts.userUri;
+	if (cmdOpts.organizationUri !== undefined) query.organization_uri = cmdOpts.organizationUri;
+	if (cmdOpts.status !== undefined) query.status = cmdOpts.status;
+	if (cmdOpts.maxStartTime !== undefined) query.max_start_time = cmdOpts.maxStartTime;
+	if (cmdOpts.minStartTime !== undefined) query.min_start_time = cmdOpts.minStartTime;
+	if (cmdOpts.count !== undefined) query.count = cmdOpts.count;
+	if (cmdOpts.includeInvitees === true) query.include_invitees = true;
+	if (cmdOpts.expand !== undefined) query.expand = cmdOpts.expand;
+	return query;
+}
+
+async function fetchScheduledEventsWithInvitees(query: Record<string, unknown>, timeout: number): Promise<any> {
+	const apiKey = process.env.CALENDLY_API_KEY;
+	if (!apiKey) throw new Error('CALENDLY_API_KEY environment variable is required');
+
+	const params = toCalendlyScheduledEventsParams({
+		user_uri: query.user_uri as string | undefined,
+		organization_uri: query.organization_uri as string | undefined,
+		status: query.status as string | undefined,
+		max_start_time: query.max_start_time as string | undefined,
+		min_start_time: query.min_start_time as string | undefined,
+		count: query.count as number | undefined,
+		expand: query.expand as string | string[] | undefined,
+		include_invitees: query.include_invitees as boolean | undefined,
+	});
+
+	const response = await axios.get(
+		`https://api.calendly.com/scheduled_events?${params.toString()}`,
+		{
+			headers: {
+				'Authorization': `Bearer ${apiKey}`,
+				'Content-Type': 'application/json',
+			},
+			timeout,
+		}
+	);
+
+	const events = Array.isArray(response.data?.collection) ? response.data.collection : [];
+	return {
+		...response.data,
+		collection: events.map((event: any) => ({
+			...event,
+			invitees: normalizeInvitees(event?.invitees),
+			invitee_count: eventInviteeCount(event),
+		})),
+		meta: {
+			...(response.data?.meta ?? {}),
+			...extractInviteePaginationMeta(response.data),
+		},
+	};
+}
+
+function printEventsWithInviteesResult(resultData: any, format: string): void {
+	const events = Array.isArray(resultData?.collection) ? resultData.collection : [];
+	if (format === 'json' || format === 'raw') {
+		console.log(JSON.stringify(resultData, null, 2));
+		return;
+	}
+	if (format === 'markdown') {
+		if (events.length === 0) {
+			console.log('No events found.');
+			return;
+		}
+		console.log('## Events with Invitees\n');
+		console.log('| Event | Start Time | Status | Invitees |');
+		console.log('|-------|------------|--------|----------|');
+		for (const event of events) {
+			const inviteeNames = normalizeInvitees(event.invitees).map((i: any) => i.name || i.email).join(', ') || 'None';
+			console.log(`| ${event.name} | ${event.start_time} | ${event.status} | ${event.invitee_count || 0} (${inviteeNames}) |`);
+		}
+		return;
+	}
+
+	if (events.length === 0) {
+		console.log('No events found.');
+		return;
+	}
+	console.log('Events with Invitees:\n');
+	for (const event of events) {
+		console.log(`Event: ${event.name}`);
+		console.log(`  Start: ${event.start_time}`);
+		console.log(`  Status: ${event.status}`);
+		console.log('  Invitees:');
+		const invitees = normalizeInvitees(event.invitees);
+		if (invitees.length === 0) {
+			console.log('    (none)');
+		} else {
+			for (const invitee of invitees) {
+				console.log(`    - ${invitee.name || invitee.email} (${invitee.email})`);
+			}
+		}
+		console.log('');
+	}
+}
 
 program
 	.command("get-oauth-url")
@@ -487,9 +597,9 @@ program
 
 program
 	.command("list-events")
-	.summary("list-events [--user-uri <user-uri>] [--organization-uri <organization-uri>] [--status <status:active|canceled>] [--max-start-time <max-start-time:iso-8601>] [--min-start-time <min-start-time:iso-8601>] [--raw <json>]")
-	.description("List scheduled events for the authenticated user")
-	.usage("[--user-uri <user-uri>] [--organization-uri <organization-uri>] [--status <status:active|canceled>] [--max-start-time <max-start-time:iso-8601>] [--min-start-time <min-start-time:iso-8601>] [--raw <json>]")
+	.summary("list-events [--user-uri <user-uri>] [--organization-uri <organization-uri>] [--status <status:active|canceled>] [--max-start-time <max-start-time:iso-8601>] [--min-start-time <min-start-time:iso-8601>] [--include-invitees] [--expand <expand:invitees>] [--raw <json>]")
+	.description("List scheduled events; use --include-invitees for invitee details in one call")
+	.usage("[--user-uri <user-uri>] [--organization-uri <organization-uri>] [--status <status:active|canceled>] [--max-start-time <max-start-time:iso-8601>] [--min-start-time <min-start-time:iso-8601>] [--include-invitees] [--expand <expand:invitees>] [--raw <json>]")
 	.option('--raw <json>', 'Provide raw JSON arguments to the tool, bypassing flag parsing.')
 
 	.option("--user-uri <user-uri>", "URI of the user whose events to list")
@@ -498,22 +608,30 @@ program
 	.option("--max-start-time <max-start-time:iso-8601>", "Maximum start time for events (ISO 8601 format)")
 	.option("--min-start-time <min-start-time:iso-8601>", "Minimum start time for events (ISO 8601 format)")
 	.option("--count <count:number>", "Number of events to return (default 20, max 100) (example: 1)", (value) => parseFloat(value))
+	.option("--include-invitees", "Include invitee details using Calendly expand=invitees in the same list-events call")
+	.option("--expand <expand:invitees>", "Compatibility expand value; currently supports invitees")
 	
 	.alias("list_events")	.action(async (cmdOpts) => {
 		const globalOptions = program.opts();
+		const args = normalizeListEventsQuery(cmdOpts, cmdOpts.raw ? JSON.parse(cmdOpts.raw) : {});
+		if (shouldIncludeInvitees(args)) {
+			try {
+				const resultData = await fetchScheduledEventsWithInvitees(args, globalOptions.timeout || 30000);
+				printEventsWithInviteesResult(resultData, globalOptions.output ?? 'text');
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				console.error(`Error: ${message}`);
+				process.exit(1);
+			}
+			return;
+		}
+
 		const runtime = await ensureRuntime();
 		const serverName = embeddedName;
 		const proxy = createServerProxy(runtime, serverName, {
 			initialSchemas: embeddedSchemas,
 		});
 		try {
-			const args = cmdOpts.raw ? JSON.parse(cmdOpts.raw) : ({} as Record<string, unknown>);
-			if (cmdOpts.userUri !== undefined) args.user_uri = cmdOpts.userUri;
-		if (cmdOpts.organizationUri !== undefined) args.organization_uri = cmdOpts.organizationUri;
-		if (cmdOpts.status !== undefined) args.status = cmdOpts.status;
-		if (cmdOpts.maxStartTime !== undefined) args.max_start_time = cmdOpts.maxStartTime;
-		if (cmdOpts.minStartTime !== undefined) args.min_start_time = cmdOpts.minStartTime;
-		if (cmdOpts.count !== undefined) args.count = cmdOpts.count;
 			const call = (proxy.listEvents as any)(args);
 			const result = await invokeWithTimeout(call, globalOptions.timeout || 30000);
 			printResult(result, globalOptions.output ?? 'text');
@@ -521,13 +639,13 @@ program
 			await runtime.close(serverName).catch(() => {});
 		}
 	})
-	.addHelpText('after', () => '\nExample:\n  ' + "mcporter call calendly.list_events(status: \"active\")")
+	.addHelpText('after', () => '\nExample:\n  ' + "./calendly list-events --status active --include-invitees")
 	.addHelpText('afterAll', () => '\n' + "// optional (1): count" + '\n');
 
 program
 	.command("list-events-with-invitees")
 	.summary("list-events-with-invitees [--user-uri <user-uri>] [--organization-uri <organization-uri>] [--status <status:active|canceled>] [--max-start-time <max-start-time:iso-8601>] [--min-start-time <min-start-time:iso-8601>] [--count <count:number>]")
-	.description("List scheduled events with invitee details in a single API call using Calendly's expand=invitees parameter")
+	.description("Compatibility command: equivalent to list-events --include-invitees")
 	.usage("[--user-uri <user-uri>] [--organization-uri <organization-uri>] [--status <status:active|canceled>] [--max-start-time <max-start-time:iso-8601>] [--min-start-time <min-start-time:iso-8601>] [--count <count:number>] [--raw <json>]")
 	.option('--raw <json>', 'Provide raw JSON arguments to the tool, bypassing flag parsing.')
 
@@ -541,95 +659,18 @@ program
 	.action(async (cmdOpts) => {
 		const globalOptions = program.opts();
 		try {
-			// Get API key from environment
-			const apiKey = process.env.CALENDLY_API_KEY;
-			if (!apiKey) {
-				throw new Error('CALENDLY_API_KEY environment variable is required');
-			}
-			
-			// Build URL with parameters
-			const urlParams = new URLSearchParams();
-			urlParams.append('expand', 'invitees');
-			
-			if (cmdOpts.userUri) {
-				urlParams.append('user', cmdOpts.userUri);
-			}
-			if (cmdOpts.organizationUri) {
-				urlParams.append('organization', cmdOpts.organizationUri);
-			}
-			if (cmdOpts.status) {
-				urlParams.append('status', cmdOpts.status);
-			}
-			if (cmdOpts.maxStartTime) {
-				urlParams.append('max_start_time', cmdOpts.maxStartTime);
-			}
-			if (cmdOpts.minStartTime) {
-				urlParams.append('min_start_time', cmdOpts.minStartTime);
-			}
-			if (cmdOpts.count) {
-				urlParams.append('count', cmdOpts.count.toString());
-			}
-			
-			const response = await axios.get(
-				`https://api.calendly.com/scheduled_events?${urlParams.toString()}`,
-				{
-					headers: {
-						'Authorization': `Bearer ${apiKey}`,
-						'Content-Type': 'application/json',
-					},
-					timeout: 30000,
-				}
-			);
-			
-			// Format output similar to other commands
-			const outputFormat = globalOptions.output ?? 'text';
-			if (outputFormat === 'json' || outputFormat === 'raw') {
-				console.log(JSON.stringify(response.data, null, 2));
-			} else if (outputFormat === 'markdown') {
-				// Format as markdown table
-				const events = response.data.collection || [];
-				if (events.length === 0) {
-					console.log('No events found.');
-					return;
-				}
-				console.log('## Events with Invitees\n');
-				console.log('| Event | Start Time | Status | Invitees |');
-				console.log('|-------|------------|--------|----------|');
-				for (const event of events) {
-					const inviteeCount = event.invitees?.length || 0;
-					const inviteeNames = event.invitees?.map((i: any) => i.name || i.email).join(', ') || 'None';
-					console.log(`| ${event.name} | ${event.start_time} | ${event.status} | ${inviteeCount} (${inviteeNames}) |`);
-				}
-			} else {
-				// Default text format
-				const events = response.data.collection || [];
-				if (events.length === 0) {
-					console.log('No events found.');
-					return;
-				}
-				console.log('Events with Invitees:\n');
-				for (const event of events) {
-					console.log(`Event: ${event.name}`);
-					console.log(`  Start: ${event.start_time}`);
-					console.log(`  Status: ${event.status}`);
-					console.log(`  Invitees:`);
-					if (event.invitees && event.invitees.length > 0) {
-						for (const invitee of event.invitees) {
-							console.log(`    - ${invitee.name || invitee.email} (${invitee.email})`);
-						}
-					} else {
-						console.log('    (none)');
-					}
-					console.log('');
-				}
-			}
+			const args = normalizeListEventsQuery(cmdOpts, cmdOpts.raw ? JSON.parse(cmdOpts.raw) : {});
+			args.include_invitees = true;
+			args.expand = 'invitees';
+			const resultData = await fetchScheduledEventsWithInvitees(args, globalOptions.timeout || 30000);
+			printEventsWithInviteesResult(resultData, globalOptions.output ?? 'text');
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			console.error(`Error: ${message}`);
 			process.exit(1);
 		}
 	})
-	.addHelpText('after', () => '\nExample:\n  ' + "./calendly list-events-with-invitees --status active");
+	.addHelpText('after', () => '\nExample:\n  ' + "./calendly list-events --status active --include-invitees");
 
 program
 	.command("search-invitees")

--- a/list-events-invitees.test.ts
+++ b/list-events-invitees.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from 'bun:test';
+import {
+	eventInviteeCount,
+	extractInviteePaginationMeta,
+	normalizeExpandValues,
+	normalizeInvitees,
+	shouldIncludeInvitees,
+	toCalendlyScheduledEventsParams,
+} from './src/list-events-invitees';
+
+describe('normalizeExpandValues', () => {
+	test('handles csv, arrays and empty values', () => {
+		expect(normalizeExpandValues(' invitees , location ')).toEqual(['invitees', 'location']);
+		expect(normalizeExpandValues(['invitees,location', ' questions '])).toEqual(['invitees', 'location', 'questions']);
+		expect(normalizeExpandValues(undefined)).toEqual([]);
+	});
+});
+
+describe('shouldIncludeInvitees', () => {
+	test('enables invitees from explicit flag or expand value', () => {
+		expect(shouldIncludeInvitees({ include_invitees: true })).toBe(true);
+		expect(shouldIncludeInvitees({ expand: 'invitees' })).toBe(true);
+		expect(shouldIncludeInvitees({ expand: ['location', 'invitees'] })).toBe(true);
+		expect(shouldIncludeInvitees({ expand: 'location' })).toBe(false);
+	});
+});
+
+describe('toCalendlyScheduledEventsParams', () => {
+	test('builds compatibility params without invitee expansion by default', () => {
+		const params = toCalendlyScheduledEventsParams({
+			user_uri: 'https://api.calendly.com/users/U',
+			status: 'active',
+			count: 20,
+		});
+		expect(params.get('user')).toBe('https://api.calendly.com/users/U');
+		expect(params.get('status')).toBe('active');
+		expect(params.get('count')).toBe('20');
+		expect(params.get('expand')).toBeNull();
+	});
+
+	test('adds invitee expansion when requested', () => {
+		const params = toCalendlyScheduledEventsParams({ include_invitees: true });
+		expect(params.get('expand')).toBe('invitees');
+	});
+});
+
+describe('normalizeInvitees and eventInviteeCount', () => {
+	test('parses invitees arrays and ignores invalid values', () => {
+		const invitees = normalizeInvitees([
+			{ email: 'one@example.com', name: 'One' },
+			null,
+			'bad',
+			{ email: 'two@example.com' },
+		]);
+		expect(invitees.length).toBe(2);
+		expect(invitees[0].email).toBe('one@example.com');
+		expect(eventInviteeCount({ invitees })).toBe(2);
+	});
+
+	test('returns empty array/count for empty and non-array cases', () => {
+		expect(normalizeInvitees(undefined)).toEqual([]);
+		expect(normalizeInvitees({})).toEqual([]);
+		expect(eventInviteeCount({ invitees: undefined })).toBe(0);
+		expect(eventInviteeCount({ invitees: [] })).toBe(0);
+	});
+});
+
+describe('extractInviteePaginationMeta', () => {
+	test('tracks pagination token presence', () => {
+		expect(extractInviteePaginationMeta({ pagination: { next_page_token: 'abc' } })).toEqual({
+			has_more: true,
+			next_page_token: 'abc',
+		});
+		expect(extractInviteePaginationMeta({ pagination: { next_page_token: '' } })).toEqual({
+			has_more: false,
+			next_page_token: undefined,
+		});
+		expect(extractInviteePaginationMeta({})).toEqual({
+			has_more: false,
+			next_page_token: undefined,
+		});
+	});
+});

--- a/src/list-events-invitees.ts
+++ b/src/list-events-invitees.ts
@@ -1,0 +1,76 @@
+export type ListEventsInviteesQuery = {
+	user_uri?: string;
+	organization_uri?: string;
+	status?: string;
+	max_start_time?: string;
+	min_start_time?: string;
+	count?: number;
+	expand?: string | string[];
+	include_invitees?: boolean;
+};
+
+export type Invitee = {
+	email?: string;
+	name?: string;
+};
+
+export type InviteePaginationMeta = {
+	has_more: boolean;
+	next_page_token?: string;
+};
+
+export function normalizeExpandValues(expand: unknown): string[] {
+	if (Array.isArray(expand)) {
+		return expand
+			.flatMap((entry) => String(entry).split(','))
+			.map((entry) => entry.trim().toLowerCase())
+			.filter(Boolean);
+	}
+	if (typeof expand === 'string') {
+		return expand
+			.split(',')
+			.map((entry) => entry.trim().toLowerCase())
+			.filter(Boolean);
+	}
+	return [];
+}
+
+export function shouldIncludeInvitees(options: ListEventsInviteesQuery): boolean {
+	if (options.include_invitees === true) {
+		return true;
+	}
+	const expands = normalizeExpandValues(options.expand);
+	return expands.includes('invitees');
+}
+
+export function toCalendlyScheduledEventsParams(options: ListEventsInviteesQuery): URLSearchParams {
+	const params = new URLSearchParams();
+	if (options.user_uri) params.append('user', options.user_uri);
+	if (options.organization_uri) params.append('organization', options.organization_uri);
+	if (options.status) params.append('status', options.status);
+	if (options.max_start_time) params.append('max_start_time', options.max_start_time);
+	if (options.min_start_time) params.append('min_start_time', options.min_start_time);
+	if (options.count !== undefined) params.append('count', String(options.count));
+	if (shouldIncludeInvitees(options)) params.append('expand', 'invitees');
+	return params;
+}
+
+export function normalizeInvitees(invitees: unknown): Invitee[] {
+	if (!Array.isArray(invitees)) {
+		return [];
+	}
+	return invitees.filter((invitee) => Boolean(invitee) && typeof invitee === 'object') as Invitee[];
+}
+
+export function eventInviteeCount(event: any): number {
+	return normalizeInvitees(event?.invitees).length;
+}
+
+export function extractInviteePaginationMeta(responseData: any): InviteePaginationMeta {
+	const token = responseData?.pagination?.next_page_token;
+	const nextPageToken = typeof token === 'string' && token.length > 0 ? token : undefined;
+	return {
+		has_more: Boolean(nextPageToken),
+		next_page_token: nextPageToken,
+	};
+}


### PR DESCRIPTION
## What
- Added invitee expansion support directly to `list-events` via `--include-invitees` and `--expand invitees`.
- Kept backward compatibility by preserving `list-events-with-invitees` as a compatibility command that reuses the same single-call workflow.
- Centralized invitee expansion/query parsing/pagination-meta handling in `src/list-events-invitees.ts`.
- Added tests in `list-events-invitees.test.ts` for invitee parsing, empty/non-array cases, pagination token behavior, and param/output compatibility defaults.
- Updated `README.md` and `SKILL.md` examples to demonstrate one-command lookup (`list-events --include-invitees`) while documenting the compatibility alias.

## Why
Issue #19 requires a one-command workflow to show weekly demos with who booked them, avoiding multiple follow-up calls per event UUID. This change makes `list-events` solve that scenario directly while preserving existing command behavior and compatibility paths.

## Tests
- `bun test`
- `./calendly --help`
- `./calendly list-events --help`
- `./calendly list-events-with-invitees --help`

## AI Assistance
- Used: yes (Codex CLI)
- Testing level: local automated tests plus CLI help verification
- Prompt/session log: local Codex CLI session for issue #19 implementation
- I understand this code.

Closes #19
