### PR TITLE
fix(search-team): support object membership.user

### DIFF
--- a/calendly
+++ b/calendly
@@ -5,7 +5,7 @@ import { createRuntime, createServerProxy } from 'mcporter';
 import { createCallResult } from 'mcporter';
 import axios from 'axios';
 import { buildOrganizationMembershipParams } from './src/organization-memberships';
-import { filterInviteesByEmail, getCountPageWindow, getTeamSearchTruncationReason, normalizeTeamSearchOptions, toTeamMemberContext } from './search-team-helpers';
+import { filterInviteesByEmail, getCountPageWindow, getTeamSearchTruncationReason, normalizeTeamSearchOptions, toMembershipUserUri, toTeamMemberContext } from './search-team-helpers';
 import {
 	eventInviteeCount,
 	extractInviteePaginationMeta,
@@ -894,10 +894,11 @@ program
 				membershipPageLimitReached = true;
 			}
 
-			const members = memberships.filter((membership) => typeof membership?.user === 'string' && membership.user.length > 0);
+			const members = memberships.filter((membership) => Boolean(toMembershipUserUri(membership)));
 			const seenMemberUris = new Set<string>();
 			const uniqueMembers = members.filter((membership) => {
-				const userUri = String(membership.user);
+				const userUri = toMembershipUserUri(membership);
+				if (!userUri) return false;
 				if (seenMemberUris.has(userUri)) return false;
 				seenMemberUris.add(userUri);
 				return true;
@@ -917,6 +918,8 @@ program
 					break;
 				}
 				membersScanned += 1;
+				const memberUserUri = toMembershipUserUri(membership);
+				if (!memberUserUri) continue;
 				let pageToken: string | undefined;
 				let memberPages = 0;
 				let memberEventsScanned = 0;
@@ -926,7 +929,7 @@ program
 					const eventParams = new URLSearchParams();
 					eventParams.append('count', pageSize.toString());
 					eventParams.append('expand', 'invitees');
-					eventParams.append('user', String(membership.user));
+					eventParams.append('user', memberUserUri);
 					if (query.organization_uri) eventParams.append('organization', query.organization_uri);
 					if (query.status) eventParams.append('status', query.status);
 					if (query.min_start_time) eventParams.append('min_start_time', query.min_start_time);

--- a/calendly.test.ts
+++ b/calendly.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { filterInviteesByEmail, getCountPageWindow, getTeamSearchTruncationReason, normalizeTeamSearchOptions } from "./search-team-helpers";
+import { filterInviteesByEmail, getCountPageWindow, getTeamSearchTruncationReason, normalizeTeamSearchOptions, toMembershipUserUri, toTeamMemberContext } from "./search-team-helpers";
 
 describe('normalizeTeamSearchOptions', () => {
 	test('throws when email is missing', () => {
@@ -119,5 +119,63 @@ describe('getTeamSearchTruncationReason', () => {
 			memberEventPageLimitReached: false,
 			resultCapReached: true,
 		})).toBe('result_cap');
+	});
+});
+
+describe('toMembershipUserUri', () => {
+	test('extracts URI when membership.user is a string', () => {
+		expect(toMembershipUserUri({ user: 'https://api.calendly.com/users/U1' })).toBe('https://api.calendly.com/users/U1');
+	});
+
+	test('extracts URI when membership.user is an object', () => {
+		expect(
+			toMembershipUserUri({
+				user: {
+					uri: 'https://api.calendly.com/users/U2',
+					email: 'person@example.com',
+					name: 'Person',
+				},
+			})
+		).toBe('https://api.calendly.com/users/U2');
+	});
+});
+
+describe('toTeamMemberContext', () => {
+	test('uses flattened membership fields when present', () => {
+		expect(
+			toTeamMemberContext({
+				uri: 'https://api.calendly.com/organization_memberships/M1',
+				user: 'https://api.calendly.com/users/U1',
+				user_email: 'flat@example.com',
+				user_name: 'Flat Person',
+				organization: 'https://api.calendly.com/organizations/O1',
+			})
+		).toEqual({
+			membership_uri: 'https://api.calendly.com/organization_memberships/M1',
+			user_uri: 'https://api.calendly.com/users/U1',
+			user_email: 'flat@example.com',
+			user_name: 'Flat Person',
+			organization_uri: 'https://api.calendly.com/organizations/O1',
+		});
+	});
+
+	test('falls back to nested user object when flattened fields are missing', () => {
+		expect(
+			toTeamMemberContext({
+				uri: 'https://api.calendly.com/organization_memberships/M2',
+				user: {
+					uri: 'https://api.calendly.com/users/U2',
+					email: 'nested@example.com',
+					name: 'Nested Person',
+				},
+				organization: 'https://api.calendly.com/organizations/O2',
+			})
+		).toEqual({
+			membership_uri: 'https://api.calendly.com/organization_memberships/M2',
+			user_uri: 'https://api.calendly.com/users/U2',
+			user_email: 'nested@example.com',
+			user_name: 'Nested Person',
+			organization_uri: 'https://api.calendly.com/organizations/O2',
+		});
 	});
 });

--- a/search-team-helpers.ts
+++ b/search-team-helpers.ts
@@ -18,6 +18,12 @@ export type TeamMemberContext = {
 	organization_uri?: string;
 };
 
+type MembershipUserObject = {
+	uri?: unknown;
+	email?: unknown;
+	name?: unknown;
+};
+
 export function normalizeTeamSearchOptions(cmdOpts: Record<string, unknown>, rawArgs: Record<string, unknown>): TeamSearchOptions {
 	const emailInput = cmdOpts.email ?? rawArgs.email;
 	if (!emailInput || typeof emailInput !== 'string' || emailInput.trim().length === 0) {
@@ -60,13 +66,27 @@ export function filterInviteesByEmail(invitees: unknown, normalizedEmail: string
 }
 
 export function toTeamMemberContext(membership: any): TeamMemberContext {
+	const user = membership?.user as string | MembershipUserObject | undefined;
+	const nestedUser = typeof user === 'object' && user !== null ? user : undefined;
+
 	return {
 		membership_uri: membership?.uri,
-		user_uri: membership?.user,
-		user_email: membership?.user_email,
-		user_name: membership?.user_name,
+		user_uri: toMembershipUserUri(membership),
+		user_email: typeof membership?.user_email === 'string' ? membership.user_email : (typeof nestedUser?.email === 'string' ? nestedUser.email : undefined),
+		user_name: typeof membership?.user_name === 'string' ? membership.user_name : (typeof nestedUser?.name === 'string' ? nestedUser.name : undefined),
 		organization_uri: membership?.organization,
 	};
+}
+
+export function toMembershipUserUri(membership: any): string | undefined {
+	const user = membership?.user as string | MembershipUserObject | undefined;
+	if (typeof user === 'string' && user.length > 0) {
+		return user;
+	}
+	if (typeof user === 'object' && user !== null && typeof user.uri === 'string' && user.uri.length > 0) {
+		return user.uri;
+	}
+	return undefined;
 }
 
 export function getCountPageWindow(totalCount: number): { pageSize: number; maxPages: number } {


### PR DESCRIPTION
## What
- update `search-team` member extraction to accept both membership shapes:
  - `membership.user` as string URI
  - `membership.user` as object with `uri`
- update team member context mapping so `user_uri`, `user_email`, and `user_name` are resolved from either flattened membership fields or nested `membership.user` object fields
- add tests for both response shapes in `calendly.test.ts`

## Why
Some `organization_memberships` responses return expanded user objects instead of a flat string URI. `search-team` only handled the flat shape, causing member scans to skip valid users and undercount `members_scanned`.

## Tests
- `bun test`
- `./calendly search-team --email martin@shapescale.com --organization-uri https://api.calendly.com/organizations/GGHFACDOGHJPUU4M --count 1 --max-membership-pages 2 --output json`
  - verified `meta.members_scanned` = `4` (> 0)
- `codex review --base main` (no P0-P2 findings)

## AI Assistance
- Used: yes (Codex CLI)
- Testing level: automated unit tests + live smoke command + static review
- Prompt/session log link: local Codex CLI session (not publicly linkable)
- I understand this code.

Closes #36
