### PR TITLE
fix(list-events): harden date range filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,10 @@ Get your token from: https://calendly.com/integrations/api_webhooks
 ### List Events
 
 ```bash
-./calendly list-events --user-uri "<YOUR_USER_URI>"
+./calendly list-events \
+  --user-uri "<YOUR_USER_URI>" \
+  --min-start-time "2026-01-20T00:00:00Z" \
+  --max-start-time "2026-01-27T23:59:59Z"
 ```
 
 ### List Events with Invitees (Single Call)
@@ -59,6 +62,11 @@ Fallback controls:
 
 Response metadata includes `meta.invitee_hydration` with fallback usage and truncation signals such as `truncated`, `events_skipped_due_to_cap`, and `truncation_reason`.
 Backward-compatible alias still works: `./calendly list-events-with-invitees --status active`.
+
+Date-range validation rules for `list-events`, `list-events-with-invitees`, `search-invitees`, and `search-team`:
+- `--min-start-time` and `--max-start-time` must be ISO-8601 timestamps (example: `2026-01-20T00:00:00Z`)
+- when both are set, `min-start-time` must be less than or equal to `max-start-time`
+- validation is identical for normal flags and `--raw` JSON input
 
 ### Search Invitees by Email
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -16,7 +16,10 @@ Interact with Calendly scheduling via MCP-generated CLI.
 calendly get-current-user
 
 # List RECENT events (always use --min-start-time for recent queries!)
-calendly list-events --user-uri "<YOUR_USER_URI>" --min-start-time "2026-01-20T00:00:00Z"
+calendly list-events \
+  --user-uri "<YOUR_USER_URI>" \
+  --min-start-time "2026-01-20T00:00:00Z" \
+  --max-start-time "2026-01-27T23:59:59Z"
 
 # Get event details
 calendly get-event --event-uuid <UUID>
@@ -167,6 +170,11 @@ MCPORTER_CONFIG=./mcporter.json npx mcporter@latest generate-cli --server calend
 ## Important: Time Filtering
 
 **Always use `--min-start-time` when querying recent events!**
+
+Date bounds are validated:
+- `--min-start-time` and `--max-start-time` must be ISO-8601 timestamps (for example `2026-01-20T00:00:00Z`)
+- when both are provided, `min-start-time` must be less than or equal to `max-start-time`
+- validation is the same for normal flags and `--raw` input
 
 The API returns events oldest-first by default and doesn't support pagination via CLI. Without a time filter, you'll get events from years ago.
 

--- a/calendly
+++ b/calendly
@@ -6,6 +6,8 @@ import { createCallResult } from 'mcporter';
 import axios from 'axios';
 import { buildOrganizationMembershipParams } from './src/organization-memberships';
 import { filterInviteesByEmail, getCountPageWindow, getTeamSearchTruncationReason, normalizeTeamSearchOptions, toMembershipUserUri, toTeamMemberContext } from './search-team-helpers';
+import { normalizeDateRange } from './src/date-range';
+import { normalizeListEventsQuery } from './src/list-events-query';
 import {
 	eventInviteeCount,
 	extractInviteePaginationMeta,
@@ -378,20 +380,6 @@ program.configureHelp({
 });
 program.showSuggestionAfterError(true);
 
-type ListEventsCmdOptions = {
-	raw?: string;
-	userUri?: string;
-	organizationUri?: string;
-	status?: 'active' | 'canceled';
-	maxStartTime?: string;
-	minStartTime?: string;
-	count?: number;
-	includeInvitees?: boolean;
-	expand?: string;
-	hydrateInvitees?: boolean;
-	maxInviteeFetches?: number;
-};
-
 function parseBooleanFlag(value: string): boolean {
 	const normalized = String(value).trim().toLowerCase();
 	if (normalized === 'true' || normalized === '1' || normalized === 'yes') {
@@ -401,21 +389,6 @@ function parseBooleanFlag(value: string): boolean {
 		return false;
 	}
 	throw new Error(`Invalid boolean value "${value}". Use true or false.`);
-}
-
-function normalizeListEventsQuery(cmdOpts: ListEventsCmdOptions, defaults: Record<string, unknown> = {}): Record<string, unknown> {
-	const query: Record<string, unknown> = { ...defaults };
-	if (cmdOpts.userUri !== undefined) query.user_uri = cmdOpts.userUri;
-	if (cmdOpts.organizationUri !== undefined) query.organization_uri = cmdOpts.organizationUri;
-	if (cmdOpts.status !== undefined) query.status = cmdOpts.status;
-	if (cmdOpts.maxStartTime !== undefined) query.max_start_time = cmdOpts.maxStartTime;
-	if (cmdOpts.minStartTime !== undefined) query.min_start_time = cmdOpts.minStartTime;
-	if (cmdOpts.count !== undefined) query.count = cmdOpts.count;
-	if (cmdOpts.includeInvitees === true) query.include_invitees = true;
-	if (cmdOpts.expand !== undefined) query.expand = cmdOpts.expand;
-	if (cmdOpts.hydrateInvitees !== undefined) query.hydrate_invitees = cmdOpts.hydrateInvitees;
-	if (cmdOpts.maxInviteeFetches !== undefined) query.max_invitee_fetches = cmdOpts.maxInviteeFetches;
-	return query;
 }
 
 async function fetchEventInviteesPage(
@@ -749,17 +722,18 @@ program
 	.action(async (cmdOpts) => {
 		const globalOptions = program.opts();
 		try {
-			const apiKey = process.env.CALENDLY_API_KEY;
-			if (!apiKey) throw new Error('CALENDLY_API_KEY environment variable is required');
-
 			const args = cmdOpts.raw ? JSON.parse(cmdOpts.raw) : ({} as Record<string, unknown>);
 			const email = cmdOpts.email ?? args.email;
 			if (!email) throw new Error('email is required (use --email or --raw {"email":"..."})');
 			const userUri = cmdOpts.userUri ?? args.user_uri;
 			const organizationUri = cmdOpts.organizationUri ?? args.organization_uri;
 			const status = cmdOpts.status ?? args.status;
-			const minStartTime = cmdOpts.minStartTime ?? args.min_start_time;
-			const maxStartTime = cmdOpts.maxStartTime ?? args.max_start_time;
+			const { min_start_time: minStartTime, max_start_time: maxStartTime } = normalizeDateRange({
+				min_start_time: cmdOpts.minStartTime ?? args.min_start_time,
+				max_start_time: cmdOpts.maxStartTime ?? args.max_start_time,
+			});
+			const apiKey = process.env.CALENDLY_API_KEY;
+			if (!apiKey) throw new Error('CALENDLY_API_KEY environment variable is required');
 			const pageSizeInput = Number(cmdOpts.pageSize ?? args.page_size ?? 100);
 			const maxPagesInput = Number(cmdOpts.maxPages ?? args.max_pages ?? 20);
 			if (!Number.isFinite(pageSizeInput) || !Number.isFinite(maxPagesInput)) {
@@ -856,11 +830,10 @@ program
 	.action(async (cmdOpts) => {
 		const globalOptions = program.opts();
 		try {
-			const apiKey = process.env.CALENDLY_API_KEY;
-			if (!apiKey) throw new Error('CALENDLY_API_KEY environment variable is required');
-
 			const rawArgs = cmdOpts.raw ? JSON.parse(cmdOpts.raw) : ({} as Record<string, unknown>);
 			const query = normalizeTeamSearchOptions(cmdOpts as Record<string, unknown>, rawArgs);
+			const apiKey = process.env.CALENDLY_API_KEY;
+			if (!apiKey) throw new Error('CALENDLY_API_KEY environment variable is required');
 			const timeout = globalOptions.timeout || 30000;
 			const memberships: any[] = [];
 			let membershipPageToken: string | undefined;

--- a/calendly.test.ts
+++ b/calendly.test.ts
@@ -54,6 +54,29 @@ describe('normalizeTeamSearchOptions', () => {
 		)).toThrow('max_membership_pages must be a valid number');
 	});
 
+	test('rejects invalid ISO-8601 date bounds', () => {
+		expect(() => normalizeTeamSearchOptions(
+			{ email: 'person@example.com', minStartTime: '2026-01-01' },
+			{}
+		)).toThrow('min_start_time must be a valid ISO-8601 timestamp');
+
+		expect(() => normalizeTeamSearchOptions(
+			{ email: 'person@example.com', maxStartTime: 'invalid-date' },
+			{}
+		)).toThrow('max_start_time must be a valid ISO-8601 timestamp');
+	});
+
+	test('rejects min_start_time greater than max_start_time', () => {
+		expect(() => normalizeTeamSearchOptions(
+			{
+				email: 'person@example.com',
+				minStartTime: '2026-01-03T00:00:00Z',
+				maxStartTime: '2026-01-01T00:00:00Z',
+			},
+			{}
+		)).toThrow('min_start_time must be less than or equal to max_start_time');
+	});
+
 	test('clamps max membership pages to at least one', () => {
 		const options = normalizeTeamSearchOptions(
 			{ email: 'person@example.com', maxMembershipPages: 0 },

--- a/search-team-helpers.ts
+++ b/search-team-helpers.ts
@@ -1,3 +1,5 @@
+import { normalizeDateRange } from './src/date-range';
+
 export type TeamSearchOptions = {
 	email: string;
 	min_start_time?: string;
@@ -46,11 +48,15 @@ export function normalizeTeamSearchOptions(cmdOpts: Record<string, unknown>, raw
 	if (statusInput !== undefined && statusInput !== 'active' && statusInput !== 'canceled') {
 		throw new Error('status must be either "active" or "canceled"');
 	}
+	const { min_start_time, max_start_time } = normalizeDateRange({
+		min_start_time: cmdOpts.minStartTime ?? rawArgs.min_start_time,
+		max_start_time: cmdOpts.maxStartTime ?? rawArgs.max_start_time,
+	});
 
 	return {
 		email: emailInput.trim().toLowerCase(),
-		min_start_time: (cmdOpts.minStartTime ?? rawArgs.min_start_time) as string | undefined,
-		max_start_time: (cmdOpts.maxStartTime ?? rawArgs.max_start_time) as string | undefined,
+		min_start_time,
+		max_start_time,
 		status: statusInput as 'active' | 'canceled' | undefined,
 		organization_uri: (cmdOpts.organizationUri ?? rawArgs.organization_uri) as string | undefined,
 		count,

--- a/src/date-range.test.ts
+++ b/src/date-range.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test';
+import { normalizeDateRange } from './date-range';
+
+describe('normalizeDateRange', () => {
+	test('accepts min-only date range', () => {
+		expect(normalizeDateRange({
+			min_start_time: '2026-01-20T00:00:00Z',
+		})).toEqual({
+			min_start_time: '2026-01-20T00:00:00Z',
+			max_start_time: undefined,
+		});
+	});
+
+	test('accepts max-only date range', () => {
+		expect(normalizeDateRange({
+			max_start_time: '2026-01-27T23:59:59Z',
+		})).toEqual({
+			min_start_time: undefined,
+			max_start_time: '2026-01-27T23:59:59Z',
+		});
+	});
+
+	test('accepts min+max date range when min <= max', () => {
+		expect(normalizeDateRange({
+			min_start_time: '2026-01-20T00:00:00Z',
+			max_start_time: '2026-01-27T23:59:59Z',
+		})).toEqual({
+			min_start_time: '2026-01-20T00:00:00Z',
+			max_start_time: '2026-01-27T23:59:59Z',
+		});
+	});
+
+	test('rejects invalid ISO-8601 timestamps', () => {
+		expect(() => normalizeDateRange({
+			min_start_time: '2026-01-20',
+		})).toThrow('min_start_time must be a valid ISO-8601 timestamp');
+	});
+
+	test('rejects min_start_time greater than max_start_time', () => {
+		expect(() => normalizeDateRange({
+			min_start_time: '2026-01-28T00:00:00Z',
+			max_start_time: '2026-01-27T23:59:59Z',
+		})).toThrow('min_start_time must be less than or equal to max_start_time');
+	});
+});

--- a/src/date-range.ts
+++ b/src/date-range.ts
@@ -1,0 +1,46 @@
+export type DateRangeInput = {
+	min_start_time?: unknown;
+	max_start_time?: unknown;
+};
+
+export type DateRangeOutput = {
+	min_start_time?: string;
+	max_start_time?: string;
+};
+
+const ISO_8601_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(?:Z|[+-]\d{2}:\d{2})$/;
+const ISO_8601_EXAMPLE = '2026-01-20T00:00:00Z';
+
+function normalizeIso8601Timestamp(value: unknown, fieldName: 'min_start_time' | 'max_start_time'): string | undefined {
+	if (value === undefined || value === null) {
+		return undefined;
+	}
+	if (typeof value !== 'string') {
+		throw new Error(`${fieldName} must be a valid ISO-8601 timestamp (example: ${ISO_8601_EXAMPLE})`);
+	}
+	const trimmed = value.trim();
+	if (!trimmed) {
+		throw new Error(`${fieldName} must be a valid ISO-8601 timestamp (example: ${ISO_8601_EXAMPLE})`);
+	}
+	if (!ISO_8601_TIMESTAMP.test(trimmed)) {
+		throw new Error(`${fieldName} must be a valid ISO-8601 timestamp (example: ${ISO_8601_EXAMPLE})`);
+	}
+	if (Number.isNaN(Date.parse(trimmed))) {
+		throw new Error(`${fieldName} must be a valid ISO-8601 timestamp (example: ${ISO_8601_EXAMPLE})`);
+	}
+	return trimmed;
+}
+
+export function normalizeDateRange(input: DateRangeInput): DateRangeOutput {
+	const minStartTime = normalizeIso8601Timestamp(input.min_start_time, 'min_start_time');
+	const maxStartTime = normalizeIso8601Timestamp(input.max_start_time, 'max_start_time');
+
+	if (minStartTime && maxStartTime && Date.parse(minStartTime) > Date.parse(maxStartTime)) {
+		throw new Error('min_start_time must be less than or equal to max_start_time');
+	}
+
+	return {
+		min_start_time: minStartTime,
+		max_start_time: maxStartTime,
+	};
+}

--- a/src/list-events-query.test.ts
+++ b/src/list-events-query.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'bun:test';
+import { normalizeListEventsQuery } from './list-events-query';
+
+describe('normalizeListEventsQuery', () => {
+	test('applies validated date range in standard flag mode', () => {
+		const query = normalizeListEventsQuery({
+			minStartTime: '2026-01-20T00:00:00Z',
+			maxStartTime: '2026-01-27T23:59:59Z',
+		});
+		expect(query.min_start_time).toBe('2026-01-20T00:00:00Z');
+		expect(query.max_start_time).toBe('2026-01-27T23:59:59Z');
+	});
+
+	test('applies validated date range in raw mode', () => {
+		const query = normalizeListEventsQuery(
+			{},
+			{
+				min_start_time: '2026-02-01T00:00:00Z',
+				max_start_time: '2026-02-28T23:59:59Z',
+			}
+		);
+		expect(query.min_start_time).toBe('2026-02-01T00:00:00Z');
+		expect(query.max_start_time).toBe('2026-02-28T23:59:59Z');
+	});
+
+	test('keeps date-range behavior identical for include-invitees path', () => {
+		const query = normalizeListEventsQuery(
+			{
+				includeInvitees: true,
+				minStartTime: '2026-03-01T00:00:00Z',
+				maxStartTime: '2026-03-31T23:59:59Z',
+			},
+			{}
+		);
+		expect(query.include_invitees).toBe(true);
+		expect(query.min_start_time).toBe('2026-03-01T00:00:00Z');
+		expect(query.max_start_time).toBe('2026-03-31T23:59:59Z');
+	});
+
+	test('flags override raw values before validation', () => {
+		const query = normalizeListEventsQuery(
+			{
+				minStartTime: '2026-04-01T00:00:00Z',
+				maxStartTime: '2026-04-30T23:59:59Z',
+			},
+			{
+				min_start_time: '2026-05-01T00:00:00Z',
+				max_start_time: '2026-05-31T23:59:59Z',
+			}
+		);
+		expect(query.min_start_time).toBe('2026-04-01T00:00:00Z');
+		expect(query.max_start_time).toBe('2026-04-30T23:59:59Z');
+	});
+
+	test('rejects invalid ISO-8601 timestamps in raw mode', () => {
+		expect(() => normalizeListEventsQuery(
+			{},
+			{ min_start_time: '2026-03-01' }
+		)).toThrow('min_start_time must be a valid ISO-8601 timestamp');
+	});
+
+	test('rejects min_start_time > max_start_time', () => {
+		expect(() => normalizeListEventsQuery({
+			minStartTime: '2026-03-02T00:00:00Z',
+			maxStartTime: '2026-03-01T00:00:00Z',
+		})).toThrow('min_start_time must be less than or equal to max_start_time');
+	});
+});

--- a/src/list-events-query.ts
+++ b/src/list-events-query.ts
@@ -1,0 +1,48 @@
+import { normalizeDateRange } from './date-range';
+
+export type ListEventsCmdOptions = {
+	raw?: string;
+	userUri?: string;
+	organizationUri?: string;
+	status?: 'active' | 'canceled';
+	maxStartTime?: string;
+	minStartTime?: string;
+	count?: number;
+	includeInvitees?: boolean;
+	expand?: string;
+	hydrateInvitees?: boolean;
+	maxInviteeFetches?: number;
+};
+
+export function normalizeListEventsQuery(
+	cmdOpts: ListEventsCmdOptions,
+	defaults: Record<string, unknown> = {}
+): Record<string, unknown> {
+	const query: Record<string, unknown> = { ...defaults };
+	if (cmdOpts.userUri !== undefined) query.user_uri = cmdOpts.userUri;
+	if (cmdOpts.organizationUri !== undefined) query.organization_uri = cmdOpts.organizationUri;
+	if (cmdOpts.status !== undefined) query.status = cmdOpts.status;
+	if (cmdOpts.maxStartTime !== undefined) query.max_start_time = cmdOpts.maxStartTime;
+	if (cmdOpts.minStartTime !== undefined) query.min_start_time = cmdOpts.minStartTime;
+	if (cmdOpts.count !== undefined) query.count = cmdOpts.count;
+	if (cmdOpts.includeInvitees === true) query.include_invitees = true;
+	if (cmdOpts.expand !== undefined) query.expand = cmdOpts.expand;
+	if (cmdOpts.hydrateInvitees !== undefined) query.hydrate_invitees = cmdOpts.hydrateInvitees;
+	if (cmdOpts.maxInviteeFetches !== undefined) query.max_invitee_fetches = cmdOpts.maxInviteeFetches;
+
+	const { min_start_time, max_start_time } = normalizeDateRange({
+		min_start_time: query.min_start_time,
+		max_start_time: query.max_start_time,
+	});
+	if (min_start_time !== undefined) {
+		query.min_start_time = min_start_time;
+	} else {
+		delete query.min_start_time;
+	}
+	if (max_start_time !== undefined) {
+		query.max_start_time = max_start_time;
+	} else {
+		delete query.max_start_time;
+	}
+	return query;
+}


### PR DESCRIPTION
## What
- add shared date-range validator that enforces ISO-8601 timestamps for `min_start_time` and `max_start_time`
- enforce `min_start_time <= max_start_time`
- apply validation consistently across:
  - `list-events` normal flag path
  - `list-events --raw` path
  - `list-events --include-invitees` hydration path
  - `list-events-with-invitees`
  - paginated follow-up scans in `search-invitees` and `search-team`
- add tests for min-only, max-only, min+max, invalid ISO, min>max, raw-mode parity, include-invitees parity
- update `README.md` and `SKILL.md` examples/notes for validated date ranges

## Why
Issue #15 requires hardening date-range filtering so invalid bounds never reach Calendly calls and behavior stays consistent across all list-events execution paths.

## Tests
- `bun test`
- `./calendly list-events --help`
- `./calendly list-events-with-invitees --help`
- `./calendly search-invitees --help`
- `./calendly search-team --help`
- `./calendly list-events --min-start-time 2026-01-20` (expects ISO-8601 validation error)
- `./calendly list-events --min-start-time 2026-01-28T00:00:00Z --max-start-time 2026-01-27T23:59:59Z` (expects min<=max error)
- `./calendly list-events --include-invitees --raw '{"min_start_time":"2026-01-28T00:00:00Z","max_start_time":"2026-01-27T23:59:59Z"}'` (expects min<=max error)

## AI Assistance
- Used: yes (Codex CLI)
- Testing level: unit tests + CLI help/error-path checks
- Prompt/session log link: local Codex CLI session (no public URL)
- I understand this code.

Closes #15