### PR TITLE
feat(cli): add batch event invitee lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,22 @@ Supports pagination with `--page-size` and `--max-pages` for large orgs.
 This command resolves team members from organization memberships, scans each member's events in bounded pages, and returns matching events with member context.
 `--max-membership-pages` defaults to `10`; if more data exists than the configured scan limits allow, output meta includes `has_more: true` and a `truncation_reason`.
 
+### Batch Invitee Lookup by Event URI
+
+```bash
+./calendly batch-event-invitees \
+  --event-uri "https://api.calendly.com/scheduled_events/<EVENT_UUID_1>" \
+  --event-uri "https://api.calendly.com/scheduled_events/<EVENT_UUID_2>" \
+  --max-invitee-fetches 25
+```
+
+Supports repeated `--event-uri` flags plus `--raw` JSON (`event_uri` or `event_uris`), dedupes duplicate URIs in stable order, and returns normalized output:
+- `collection`: one entry per requested event URI, with per-event `error` when lookup fails
+- `meta.requested`: number of deduped input event URIs
+- `meta.processed`: successful events
+- `meta.failed`: failed events
+- `meta.truncated`: `true` when the global fetch cap prevented full completion
+
 ### Get Event Details
 
 ```bash
@@ -143,6 +159,7 @@ Signing secret handling guidance:
 - `list-event-invitees` - List invitees for a specific event
 - `search-invitees` - Search events by invitee email across paginated results
 - `search-team` - Search invitee email across team member calendars
+- `batch-event-invitees` - Batch lookup invitees for multiple scheduled event URIs
 - `list-organization-memberships` - List organization memberships
 
 ### OAuth

--- a/SKILL.md
+++ b/SKILL.md
@@ -41,6 +41,7 @@ calendly cancel-event --event-uuid <UUID> --reason "Rescheduling needed"
 
 ### Invitees
 - `list-event-invitees` - List invitees for an event (requires --event-uuid)
+- `batch-event-invitees` - Batch lookup invitees for multiple events (repeat `--event-uri`)
 - `search-invitees` - Search events by invitee email across paginated results
 
 ### Organization
@@ -102,6 +103,13 @@ calendly list-events \
 # Get event details
 calendly get-event \
   --event-uuid "<EVENT_UUID>" \
+  -o json
+
+# Batch invitee lookup for multiple events
+calendly batch-event-invitees \
+  --event-uri "https://api.calendly.com/scheduled_events/<EVENT_UUID_1>" \
+  --event-uri "https://api.calendly.com/scheduled_events/<EVENT_UUID_2>" \
+  --max-invitee-fetches 25 \
   -o json
 
 # Cancel with reason

--- a/calendly
+++ b/calendly
@@ -8,6 +8,7 @@ import { buildOrganizationMembershipParams } from './src/organization-membership
 import { filterInviteesByEmail, getCountPageWindow, getTeamSearchTruncationReason, normalizeTeamSearchOptions, toMembershipUserUri, toTeamMemberContext } from './search-team-helpers';
 import { normalizeDateRange } from './src/date-range';
 import { normalizeListEventsQuery } from './src/list-events-query';
+import { fetchBatchEventInvitees, normalizeBatchEventInviteesQuery } from './src/batch-event-invitees';
 import {
 	eventInviteeCount,
 	extractInviteePaginationMeta,
@@ -266,6 +267,12 @@ const generatorTools = [
     "flags": "--event-uuid <event-uuid> [--raw <json>]"
   },
   {
+    "name": "batch-event-invitees",
+    "description": "Batch lookup invitees for multiple scheduled event URIs",
+    "usage": "batch-event-invitees --event-uri <event-uri> [--event-uri <event-uri>] [--status <status:active|canceled>] [--email <email>] [--count <count:number>] [--max-invitee-fetches <max-invitee-fetches:number>] [--raw <json>]",
+    "flags": "--event-uri <event-uri> [--event-uri <event-uri>] [--status <status:active|canceled>] [--email <email>] [--count <count:number>] [--max-invitee-fetches <max-invitee-fetches:number>] [--raw <json>]"
+  },
+  {
     "name": "list-event-invitees",
     "description": "List invitees for a specific event",
     "usage": "list-event-invitees --event-uuid <event-uuid> [--status <status:active|canceled>] [--email <email>] [--count <count:number>] [--raw <json>]",
@@ -368,6 +375,7 @@ const commandSignatures: Record<string, string> = {
   "search-invitees": "function search_invitees(email: string, user_uri?: string, organization_uri?: string, status?: \"active\" | \"canceled\", min_start_time?: string, max_start_time?: string, page_size?: number, max_pages?: number);",
   "search-team": "function search_team(email: string, min_start_time?: string, max_start_time?: string, status?: \"active\" | \"canceled\", organization_uri?: string, count?: number, max_membership_pages?: number);",
   "get-event": "function get_event(event_uuid: string);",
+  "batch-event-invitees": "function batch_event_invitees(event_uri: string[], status?: \"active\" | \"canceled\", email?: string, count?: number, max_invitee_fetches?: number);",
   "list-event-invitees": "function list_event_invitees(event_uuid: string, status?: \"active\" | \"canceled\", email?: string, count?: number);",
   "cancel-event": "function cancel_event(event_uuid: string, reason?: string);",
   "list-organization-memberships": "function list_organization_memberships(user_uri?: string, organization_uri?: string, email?: string, count?: number);"
@@ -391,14 +399,24 @@ function parseBooleanFlag(value: string): boolean {
 	throw new Error(`Invalid boolean value "${value}". Use true or false.`);
 }
 
+function collectRepeatedString(value: string, previous: string[]): string[] {
+	return [...previous, value];
+}
+
 async function fetchEventInviteesPage(
 	apiKey: string,
 	eventUuid: string,
 	timeout: number,
-	pageToken?: string
+	pageToken?: string,
+	options?: { status?: string; email?: string; count?: number }
 ): Promise<{ collection: unknown[]; next_page_token?: string }> {
 	const params = new URLSearchParams();
-	params.append('count', '100');
+	const normalizedCount = typeof options?.count === 'number' && Number.isFinite(options.count)
+		? Math.max(1, Math.min(100, Math.trunc(options.count)))
+		: 100;
+	params.append('count', String(normalizedCount));
+	if (typeof options?.status === 'string' && options.status.length > 0) params.append('status', options.status);
+	if (typeof options?.email === 'string' && options.email.length > 0) params.append('email', options.email);
 	if (pageToken) params.append('page_token', pageToken);
 	const response = await axios.get(
 		`https://api.calendly.com/scheduled_events/${eventUuid}/invitees?${params.toString()}`,
@@ -414,6 +432,27 @@ async function fetchEventInviteesPage(
 		collection: Array.isArray(response.data?.collection) ? response.data.collection : [],
 		next_page_token: response.data?.pagination?.next_page_token,
 	};
+}
+
+async function fetchBatchEventInviteesResult(query: Record<string, unknown>, timeout: number): Promise<any> {
+	const apiKey = process.env.CALENDLY_API_KEY;
+	if (!apiKey) throw new Error('CALENDLY_API_KEY environment variable is required');
+
+	const normalizedQuery = normalizeBatchEventInviteesQuery(
+		{
+			eventUri: Array.isArray(query.event_uri) ? (query.event_uri as string[]) : undefined,
+			status: query.status as 'active' | 'canceled' | undefined,
+			email: query.email as string | undefined,
+			count: query.count as number | undefined,
+			maxInviteeFetches: query.max_invitee_fetches as number | undefined,
+		},
+		query
+	);
+
+	return fetchBatchEventInvitees(
+		normalizedQuery,
+		(eventUuid, pageToken, options) => fetchEventInviteesPage(apiKey, eventUuid, timeout, pageToken, options)
+	);
 }
 
 async function fetchScheduledEventsWithInvitees(query: Record<string, unknown>, timeout: number): Promise<any> {
@@ -1006,6 +1045,38 @@ program
 		}
 	})
 	.addHelpText('after', () => '\nExample:\n  ' + "mcporter call calendly.get_event(event_uuid: \"example-id\")");
+
+program
+	.command("batch-event-invitees")
+	.summary("batch-event-invitees --event-uri <event-uri> [--event-uri <event-uri>] [--status <status:active|canceled>] [--email <email>] [--count <count:number>] [--max-invitee-fetches <max-invitee-fetches:number>] [--raw <json>]")
+	.description("Batch lookup invitees for multiple scheduled event URIs")
+	.usage("--event-uri <event-uri> [--event-uri <event-uri>] [--status <status:active|canceled>] [--email <email>] [--count <count:number>] [--max-invitee-fetches <max-invitee-fetches:number>] [--raw <json>]")
+	.option('--raw <json>', 'Provide raw JSON arguments to the tool, bypassing flag parsing.')
+	.option("--event-uri <event-uri>", "Scheduled event URI; repeat for multiple events", collectRepeatedString, [] as string[])
+	.option("--status <status:active|canceled>", "Filter invitees by status (choices: active, canceled; example: active)")
+	.option("--email <email>", "Optional invitee email filter")
+	.option("--count <count:number>", "Number of invitees per page (default 100, max 100) (example: 25)", (value) => parseFloat(value))
+	.option("--max-invitee-fetches <max-invitee-fetches:number>", "Safety cap for total invitee fetch calls across all events (default 25)", (value) => parseInt(value, 10))
+	.alias("batch_event_invitees")
+	.action(async (cmdOpts) => {
+		const globalOptions = program.opts();
+		try {
+			const args = cmdOpts.raw ? JSON.parse(cmdOpts.raw) : ({} as Record<string, unknown>);
+			if (Array.isArray(cmdOpts.eventUri) && cmdOpts.eventUri.length > 0) args.event_uri = cmdOpts.eventUri;
+			if (cmdOpts.status !== undefined) args.status = cmdOpts.status;
+			if (cmdOpts.email !== undefined) args.email = cmdOpts.email;
+			if (cmdOpts.count !== undefined) args.count = cmdOpts.count;
+			if (cmdOpts.maxInviteeFetches !== undefined) args.max_invitee_fetches = cmdOpts.maxInviteeFetches;
+
+			const result = await fetchBatchEventInviteesResult(args, globalOptions.timeout || 30000);
+			printResult(result, globalOptions.output ?? 'text');
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			console.error(`Error: ${message}`);
+			process.exit(1);
+		}
+	})
+	.addHelpText('after', () => '\nExample:\n  ' + "./calendly batch-event-invitees --event-uri https://api.calendly.com/scheduled_events/EVT_1 --event-uri https://api.calendly.com/scheduled_events/EVT_2");
 
 program
 	.command("list-event-invitees")

--- a/src/batch-event-invitees.test.ts
+++ b/src/batch-event-invitees.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from 'bun:test';
+import { fetchBatchEventInvitees, normalizeBatchEventInviteesQuery } from './batch-event-invitees';
+
+describe('normalizeBatchEventInviteesQuery', () => {
+	test('supports a single event URI', () => {
+		const query = normalizeBatchEventInviteesQuery({
+			eventUri: ['https://api.calendly.com/scheduled_events/evt-1'],
+		});
+		expect(query.event_uris).toEqual(['https://api.calendly.com/scheduled_events/evt-1']);
+		expect(query.count).toBe(100);
+	});
+
+	test('dedupes repeated event URIs in deterministic order', () => {
+		const query = normalizeBatchEventInviteesQuery({
+			eventUri: [
+				'https://api.calendly.com/scheduled_events/evt-2',
+				'https://api.calendly.com/scheduled_events/evt-1',
+				'https://api.calendly.com/scheduled_events/evt-2',
+			],
+		});
+		expect(query.event_uris).toEqual([
+			'https://api.calendly.com/scheduled_events/evt-2',
+			'https://api.calendly.com/scheduled_events/evt-1',
+		]);
+	});
+
+	test('keeps raw and flags behavior consistent', () => {
+		const fromFlags = normalizeBatchEventInviteesQuery(
+			{
+				eventUri: [
+					'https://api.calendly.com/scheduled_events/evt-1',
+					'https://api.calendly.com/scheduled_events/evt-2',
+				],
+				status: 'active',
+				email: 'person@example.com',
+				count: 25,
+				maxInviteeFetches: 8,
+			},
+			{}
+		);
+		const fromRaw = normalizeBatchEventInviteesQuery(
+			{},
+			{
+				event_uris: [
+					'https://api.calendly.com/scheduled_events/evt-1',
+					'https://api.calendly.com/scheduled_events/evt-2',
+				],
+				status: 'active',
+				email: 'person@example.com',
+				count: 25,
+				max_invitee_fetches: 8,
+			}
+		);
+
+		expect(fromFlags).toEqual(fromRaw);
+	});
+
+	test('throws for empty input', () => {
+		expect(() => normalizeBatchEventInviteesQuery({ eventUri: [] })).toThrow('at least one event_uri is required');
+		expect(() => normalizeBatchEventInviteesQuery({}, {})).toThrow('at least one event_uri is required');
+	});
+});
+
+describe('fetchBatchEventInvitees', () => {
+	test('supports multi-event invitee lookup with deterministic ordering', async () => {
+		const result = await fetchBatchEventInvitees(
+			{
+				event_uris: [
+					'https://api.calendly.com/scheduled_events/evt-2',
+					'https://api.calendly.com/scheduled_events/evt-1',
+				],
+				status: 'active',
+				email: undefined,
+				count: 100,
+				max_invitee_fetches: 10,
+			},
+			async (eventUuid) => ({
+				collection: [{ email: `${eventUuid}@example.com` }],
+			})
+		);
+
+		expect(result.collection.map((entry) => entry.event_uuid)).toEqual(['evt-2', 'evt-1']);
+		expect(result.collection[0].invitees).toEqual([{ email: 'evt-2@example.com' }]);
+		expect(result.meta).toEqual({
+			requested: 2,
+			processed: 2,
+			failed: 0,
+			truncated: false,
+			max_invitee_fetches: 10,
+			fetches_used: 2,
+		});
+	});
+
+	test('continues with partial failures and reports per-event errors', async () => {
+		const result = await fetchBatchEventInvitees(
+			{
+				event_uris: [
+					'https://api.calendly.com/scheduled_events/evt-bad',
+					'https://api.calendly.com/scheduled_events/evt-good',
+				],
+				status: undefined,
+				email: undefined,
+				count: 100,
+				max_invitee_fetches: 10,
+			},
+			async (eventUuid) => {
+				if (eventUuid === 'evt-bad') {
+					throw new Error('timeout');
+				}
+				return { collection: [{ email: 'good@example.com' }] };
+			}
+		);
+
+		expect(result.collection[0].error).toEqual({
+			message: 'timeout',
+			reason: 'invitee_fetch_failed',
+		});
+		expect(result.collection[1].invitees).toEqual([{ email: 'good@example.com' }]);
+		expect(result.meta.processed).toBe(1);
+		expect(result.meta.failed).toBe(1);
+	});
+
+	test('reports truncation metadata when fetch cap is reached', async () => {
+		const result = await fetchBatchEventInvitees(
+			{
+				event_uris: [
+					'https://api.calendly.com/scheduled_events/evt-1',
+					'https://api.calendly.com/scheduled_events/evt-2',
+				],
+				status: undefined,
+				email: undefined,
+				count: 100,
+				max_invitee_fetches: 1,
+			},
+			async (eventUuid, pageToken) => ({
+				collection: [{ email: `${eventUuid}-one@example.com` }],
+				next_page_token: pageToken ? undefined : 'next',
+			})
+		);
+
+		expect(result.meta.truncated).toBe(true);
+		expect(result.meta.fetches_used).toBe(1);
+		expect(result.collection[0].meta.truncated).toBe(true);
+		expect(result.collection[1].error).toEqual({
+			message: 'max_invitee_fetches reached before event could be processed',
+			reason: 'max_invitee_fetches_reached',
+		});
+	});
+});

--- a/src/batch-event-invitees.ts
+++ b/src/batch-event-invitees.ts
@@ -1,0 +1,248 @@
+import { DEFAULT_MAX_INVITEE_FETCHES, getEventUuid, normalizeInvitees, normalizeMaxInviteeFetches } from './list-events-invitees';
+
+export type BatchEventInviteesCmdOptions = {
+	eventUri?: string[];
+	status?: 'active' | 'canceled';
+	email?: string;
+	count?: number;
+	maxInviteeFetches?: number;
+};
+
+export type BatchEventInviteesQuery = {
+	event_uris: string[];
+	status?: 'active' | 'canceled';
+	email?: string;
+	count: number;
+	max_invitee_fetches: number;
+};
+
+export type BatchEventInviteesResultItem = {
+	event_uri: string;
+	event_uuid: string;
+	invitees: unknown[];
+	meta: {
+		fetches_used: number;
+		has_more: boolean;
+		truncated: boolean;
+	};
+	error?: {
+		message: string;
+		reason: 'invitee_fetch_failed' | 'invalid_event_uri' | 'max_invitee_fetches_reached';
+	};
+};
+
+export type BatchEventInviteesResult = {
+	collection: BatchEventInviteesResultItem[];
+	meta: {
+		requested: number;
+		processed: number;
+		failed: number;
+		truncated: boolean;
+		max_invitee_fetches: number;
+		fetches_used: number;
+	};
+};
+
+export type EventInviteesPage = {
+	collection: unknown;
+	next_page_token?: string;
+};
+
+export type EventInviteesPageFetcher = (
+	eventUuid: string,
+	pageToken: string | undefined,
+	options: Pick<BatchEventInviteesQuery, 'status' | 'email' | 'count'>
+) => Promise<EventInviteesPage>;
+
+const DEFAULT_PER_PAGE_COUNT = 100;
+
+function normalizeEventUris(value: unknown): string[] {
+	if (Array.isArray(value)) {
+		return value.flatMap((entry) => normalizeEventUris(entry));
+	}
+	if (typeof value !== 'string') {
+		return [];
+	}
+	const trimmed = value.trim();
+	return trimmed ? [trimmed] : [];
+}
+
+function dedupeStable(values: string[]): string[] {
+	const seen = new Set<string>();
+	const result: string[] = [];
+	for (const value of values) {
+		if (seen.has(value)) {
+			continue;
+		}
+		seen.add(value);
+		result.push(value);
+	}
+	return result;
+}
+
+function normalizeStatus(value: unknown): 'active' | 'canceled' | undefined {
+	if (value === undefined || value === null || value === '') {
+		return undefined;
+	}
+	if (value === 'active' || value === 'canceled') {
+		return value;
+	}
+	throw new Error('status must be either "active" or "canceled"');
+}
+
+function normalizeCount(value: unknown): number {
+	if (value === undefined || value === null || value === '') {
+		return DEFAULT_PER_PAGE_COUNT;
+	}
+	const numeric = typeof value === 'number' ? value : Number(value);
+	if (!Number.isFinite(numeric)) {
+		throw new Error('count must be a valid number');
+	}
+	return Math.max(1, Math.min(100, Math.trunc(numeric)));
+}
+
+export function normalizeBatchEventInviteesQuery(
+	cmdOpts: BatchEventInviteesCmdOptions,
+	defaults: Record<string, unknown> = {}
+): BatchEventInviteesQuery {
+	const defaultEventUris = dedupeStable([
+		...normalizeEventUris(defaults.event_uri),
+		...normalizeEventUris(defaults.event_uris),
+	]);
+
+	const query: BatchEventInviteesQuery = {
+		event_uris: defaultEventUris,
+		status: normalizeStatus(defaults.status),
+		email: typeof defaults.email === 'string' && defaults.email.trim().length > 0 ? defaults.email.trim() : undefined,
+		count: normalizeCount(defaults.count),
+		max_invitee_fetches: normalizeMaxInviteeFetches(defaults.max_invitee_fetches, DEFAULT_MAX_INVITEE_FETCHES),
+	};
+
+	if (Array.isArray(cmdOpts.eventUri) && cmdOpts.eventUri.length > 0) {
+		query.event_uris = dedupeStable(normalizeEventUris(cmdOpts.eventUri));
+	}
+	if (cmdOpts.status !== undefined) query.status = normalizeStatus(cmdOpts.status);
+	if (cmdOpts.email !== undefined) query.email = cmdOpts.email.trim() || undefined;
+	if (cmdOpts.count !== undefined) query.count = normalizeCount(cmdOpts.count);
+	if (cmdOpts.maxInviteeFetches !== undefined) {
+		query.max_invitee_fetches = normalizeMaxInviteeFetches(cmdOpts.maxInviteeFetches, DEFAULT_MAX_INVITEE_FETCHES);
+	}
+
+	if (query.event_uris.length === 0) {
+		throw new Error('at least one event_uri is required');
+	}
+	return query;
+}
+
+export async function fetchBatchEventInvitees(
+	query: BatchEventInviteesQuery,
+	fetchInviteesPage: EventInviteesPageFetcher
+): Promise<BatchEventInviteesResult> {
+	const collection: BatchEventInviteesResultItem[] = [];
+	let processed = 0;
+	let failed = 0;
+	let fetchesUsed = 0;
+	let truncated = false;
+
+	for (const eventUri of query.event_uris) {
+		const eventUuid = getEventUuid({ uri: eventUri });
+		if (!eventUuid) {
+			failed += 1;
+			collection.push({
+				event_uri: eventUri,
+				event_uuid: '',
+				invitees: [],
+				meta: { fetches_used: 0, has_more: false, truncated: false },
+				error: {
+					message: 'unable to parse event UUID from event_uri',
+					reason: 'invalid_event_uri',
+				},
+			});
+			continue;
+		}
+
+		if (fetchesUsed >= query.max_invitee_fetches) {
+			truncated = true;
+			failed += 1;
+			collection.push({
+				event_uri: eventUri,
+				event_uuid: eventUuid,
+				invitees: [],
+				meta: { fetches_used: 0, has_more: true, truncated: true },
+				error: {
+					message: 'max_invitee_fetches reached before event could be processed',
+					reason: 'max_invitee_fetches_reached',
+				},
+			});
+			continue;
+		}
+
+		const invitees: unknown[] = [];
+		let pageToken: string | undefined;
+		let eventTruncated = false;
+		let eventFetches = 0;
+		let eventError: Error | undefined;
+
+		while (true) {
+			if (fetchesUsed >= query.max_invitee_fetches) {
+				truncated = true;
+				eventTruncated = true;
+				break;
+			}
+
+			fetchesUsed += 1;
+			eventFetches += 1;
+			try {
+				const page = await fetchInviteesPage(eventUuid, pageToken, query);
+				invitees.push(...normalizeInvitees(page?.collection));
+				const nextPageToken = typeof page?.next_page_token === 'string' && page.next_page_token.length > 0
+					? page.next_page_token
+					: undefined;
+				if (!nextPageToken) {
+					break;
+				}
+				pageToken = nextPageToken;
+			} catch (error) {
+				eventError = error instanceof Error ? error : new Error(String(error));
+				break;
+			}
+		}
+
+		const hasMore = Boolean(pageToken) || eventTruncated;
+		if (eventError) {
+			failed += 1;
+		} else {
+			processed += 1;
+		}
+		collection.push({
+			event_uri: eventUri,
+			event_uuid: eventUuid,
+			invitees,
+			meta: {
+				fetches_used: eventFetches,
+				has_more: hasMore,
+				truncated: eventTruncated,
+			},
+			...(eventError
+				? {
+					error: {
+						message: eventError.message,
+						reason: 'invitee_fetch_failed' as const,
+					},
+				}
+				: {}),
+		});
+	}
+
+	return {
+		collection,
+		meta: {
+			requested: query.event_uris.length,
+			processed,
+			failed,
+			truncated,
+			max_invitee_fetches: query.max_invitee_fetches,
+			fetches_used: fetchesUsed,
+		},
+	};
+}


### PR DESCRIPTION
## What
- add `batch-event-invitees` command for batch invitee lookup across multiple scheduled events
- support repeated `--event-uri` flags and raw JSON input (`event_uri` or `event_uris`) through a shared normalizer
- enforce deterministic ordering with stable URI dedupe
- implement bounded total invitee fetch cap via `--max-invitee-fetches`
- implement partial success behavior: per-event errors are returned in `collection` without failing the whole request
- normalize output shape to `{ collection, meta }` with `meta.requested`, `meta.processed`, `meta.failed`, and `meta.truncated`
- reuse existing invitee pagination/fetch helper by extending it for optional status/email/count filters
- add tests for single/multi lookup, duplicate URI dedupe, partial failure isolation, raw parity, truncation metadata, and empty input validation
- update `README.md` and `SKILL.md` examples for the new command

## Why
Issue #16 requests batch invitee lookup to avoid repeated single-event calls. This change adds a dedicated batch command using existing architecture patterns while preserving deterministic and inspectable behavior under failures and fetch limits.

## Tests
- `bun test`
- `./calendly --help`
- `./calendly batch-event-invitees --help`

## AI Assistance
- Used: yes (Codex CLI)
- Testing level: unit tests + CLI help checks executed locally
- Prompt/session log: Codex CLI session (local)
- I understand this code.

Closes #16
