### PR TITLE
feat(cli): add get-event-type-availability command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Moltbot skill for Calendly integration. List events, check availability, manage 
 - **Invitee Management**: View event invitees
 - **Organization**: List organization memberships
 
-> **Note:** Scheduling API features (list-event-types, get-event-type-availability, schedule-event) are available in calendly-mcp-server v2.0.0, which is currently unreleased. This skill uses v1.0.0 from npm for portability. See [Upgrade to v2.0](#upgrade-to-v20) for instructions once published.
+> **Note:** This CLI now includes `get-event-type-availability` with strict argument validation and REST fallback support. Other Scheduling API features (`list-event-types`, `schedule-event`) still depend on calendly-mcp-server v2.0.0 being published to npm.
 
 ## Installation
 
@@ -101,6 +101,24 @@ Supports repeated `--event-uri` flags plus `--raw` JSON (`event_uri` or `event_u
 - `meta.failed`: failed events
 - `meta.truncated`: `true` when the global fetch cap prevented full completion
 
+### Get Event Type Availability
+
+```bash
+./calendly get-event-type-availability \
+  --event-type-uri "https://api.calendly.com/event_types/<EVENT_TYPE_UUID>" \
+  --start-time "2026-03-01T00:00:00Z" \
+  --end-time "2026-03-02T00:00:00Z" \
+  --timezone "America/New_York" \
+  -o json
+```
+
+Validation rules:
+- `--event-type-uri`, `--start-time`, and `--end-time` are required (also enforced for `--raw` JSON).
+- `--start-time`/`--end-time` must be ISO-8601 timestamps.
+- `start-time` must be less than or equal to `end-time`.
+- availability window must be 7 days or less.
+- `--timezone` is optional and must be a valid IANA timezone.
+
 ### Get Event Details
 
 ```bash
@@ -155,6 +173,7 @@ Signing secret handling guidance:
 - `list-events` - List scheduled events (`--include-invitees` for expand + bounded fallback invitee hydration)
 - `list-events-with-invitees` - Compatibility alias for include-invitees path
 - `get-event` - Get event details
+- `get-event-type-availability` - Get available time slots for a specific event type
 - `cancel-event` - Cancel an event
 - `list-event-invitees` - List invitees for a specific event
 - `search-invitees` - Search events by invitee email across paginated results
@@ -193,19 +212,18 @@ Then use in conversations:
 
 ## Upgrade to v2.0
 
-Once calendly-mcp-server v2.0.0 is published to npm (adds Scheduling API with event types, availability, and programmatic scheduling), regenerate the CLI:
+Once calendly-mcp-server v2.0.0 is published to npm (adds the remaining Scheduling API surface), regenerate the CLI:
 
 ```bash
 # Update to v2.0+
 MCPORTER_CONFIG=./mcporter.json npx mcporter@latest generate-cli --server calendly --output calendly
 
 # Verify new commands appear
-./calendly --help | grep -E "list-event-types|get-event-type-availability|schedule-event"
+./calendly --help | grep -E "list-event-types|schedule-event"
 ```
 
-The v2.0 Scheduling API will add:
+The remaining v2.0 Scheduling API commands will add:
 - `list-event-types` - List available event types for scheduling
-- `get-event-type-availability` - Get available time slots
 - `schedule-event` - Schedule meetings programmatically
 
 **Requires:** Paid Calendly plan (Standard or higher)

--- a/SKILL.md
+++ b/SKILL.md
@@ -7,7 +7,7 @@ description: Calendly scheduling integration. List events, check availability, m
 
 Interact with Calendly scheduling via MCP-generated CLI.
 
-> **Note:** Scheduling API features (list-event-types, get-event-type-availability, schedule-event) will be available once calendly-mcp-server v2.0.0 is published to npm. Current CLI uses v1.0.0 for portability.
+> **Note:** This CLI includes `get-event-type-availability` with strict input validation and REST fallback. Remaining Scheduling API features (`list-event-types`, `schedule-event`) still require calendly-mcp-server v2.0.0 on npm.
 
 ## Quick Start
 
@@ -37,6 +37,7 @@ calendly cancel-event --event-uuid <UUID> --reason "Rescheduling needed"
 - `list-events` - List scheduled events (requires --user-uri); add `--include-invitees` for expand + bounded fallback invitee hydration
 - `list-events-with-invitees` - Compatibility alias for include-invitees path
 - `get-event` - Get event details (requires --event-uuid)
+- `get-event-type-availability` - Get available slots for an event type (`--event-type-uri`, `--start-time`, `--end-time`; optional `--timezone`)
 - `cancel-event` - Cancel an event (requires --event-uuid, optional --reason)
 
 ### Invitees
@@ -105,6 +106,14 @@ calendly get-event \
   --event-uuid "<EVENT_UUID>" \
   -o json
 
+# Get event type availability
+calendly get-event-type-availability \
+  --event-type-uri "https://api.calendly.com/event_types/<EVENT_TYPE_UUID>" \
+  --start-time "2026-03-01T00:00:00Z" \
+  --end-time "2026-03-02T00:00:00Z" \
+  --timezone "America/New_York" \
+  -o json
+
 # Batch invitee lookup for multiple events
 calendly batch-event-invitees \
   --event-uri "https://api.calendly.com/scheduled_events/<EVENT_UUID_1>" \
@@ -144,19 +153,16 @@ Webhook signing secret guidance:
 - Verify Calendly webhook signatures in your receiver with the same secret used at subscription creation.
 - If using `--scope user`, include `--user-uri "https://api.calendly.com/users/<USER_UUID>"`.
 
-## Coming Soon: Scheduling API (v2.0)
+## Remaining Scheduling API (v2.0)
 
-Once calendly-mcp-server v2.0.0 is published, these commands will be available:
+Once calendly-mcp-server v2.0.0 is published, these additional commands will be available:
 
 ### Scheduling Workflow
 ```bash
 # 1. List available event types
 calendly list-event-types
 
-# 2. Check availability for a specific event type
-calendly get-event-type-availability --event-type "<EVENT_TYPE_URI>"
-
-# 3. Schedule a meeting (requires paid Calendly plan)
+# 2. Schedule a meeting (requires paid Calendly plan)
 calendly schedule-event \
   --event-type "<EVENT_TYPE_URI>" \
   --start-time "2026-01-25T19:00:00Z" \
@@ -219,5 +225,5 @@ calendly list-events --user-uri "<URI>" --min-start-time "$(date -u +%Y-%m-%dT%H
 ---
 
 **Generated:** 2026-01-20  
-**Updated:** 2026-02-22 (Webhook lifecycle guidance + invitee hydration fallback controls)
+**Updated:** 2026-02-23 (Added get-event-type-availability command with validation + REST fallback)
 **Source:** meAmitPatil/calendly-mcp-server via mcporter

--- a/calendly
+++ b/calendly
@@ -9,6 +9,7 @@ import { filterInviteesByEmail, getCountPageWindow, getTeamSearchTruncationReaso
 import { normalizeDateRange } from './src/date-range';
 import { normalizeListEventsQuery } from './src/list-events-query';
 import { fetchBatchEventInvitees, normalizeBatchEventInviteesQuery } from './src/batch-event-invitees';
+import { normalizeEventTypeAvailabilityQuery, shapeEventTypeAvailabilityResult } from './src/event-type-availability';
 import {
 	eventInviteeCount,
 	extractInviteePaginationMeta,
@@ -128,6 +129,32 @@ const embeddedSchemas = {
       }
     },
     "required": []
+  },
+  "get_event_type_availability": {
+    "type": "object",
+    "properties": {
+      "event_type": {
+        "type": "string",
+        "description": "URI of the event type to check availability for"
+      },
+      "start_time": {
+        "type": "string",
+        "description": "Start time for availability window (ISO 8601 format)"
+      },
+      "end_time": {
+        "type": "string",
+        "description": "End time for availability window (ISO 8601 format)"
+      },
+      "timezone": {
+        "type": "string",
+        "description": "Optional IANA timezone for slot conversion"
+      }
+    },
+    "required": [
+      "event_type",
+      "start_time",
+      "end_time"
+    ]
   },
   "get_event": {
     "type": "object",
@@ -261,6 +288,12 @@ const generatorTools = [
     "flags": "--email <email> [--min-start-time <min-start-time:iso-8601>] [--max-start-time <max-start-time:iso-8601>] [--status <status:active|canceled>] [--organization-uri <organization-uri>] [--count <count:number>] [--max-membership-pages <max-membership-pages:number>]"
   },
   {
+    "name": "get-event-type-availability",
+    "description": "Get available time slots for a specific event type",
+    "usage": "get-event-type-availability --event-type-uri <event-type-uri> --start-time <start-time:iso-8601> --end-time <end-time:iso-8601> [--timezone <timezone>] [--raw <json>]",
+    "flags": "--event-type-uri <event-type-uri> --start-time <start-time:iso-8601> --end-time <end-time:iso-8601> [--timezone <timezone>] [--raw <json>]"
+  },
+  {
     "name": "get-event",
     "description": "Get details of a specific event",
     "usage": "get-event --event-uuid <event-uuid> [--raw <json>]",
@@ -374,6 +407,7 @@ const commandSignatures: Record<string, string> = {
   "list-events-with-invitees": "function list_events_with_invitees(user_uri?: string, organization_uri?: string, status?: \"active\" | \"canceled\", max_start_time?: string, min_start_time?: string, count?: number, hydrate_invitees?: boolean, max_invitee_fetches?: number);",
   "search-invitees": "function search_invitees(email: string, user_uri?: string, organization_uri?: string, status?: \"active\" | \"canceled\", min_start_time?: string, max_start_time?: string, page_size?: number, max_pages?: number);",
   "search-team": "function search_team(email: string, min_start_time?: string, max_start_time?: string, status?: \"active\" | \"canceled\", organization_uri?: string, count?: number, max_membership_pages?: number);",
+  "get-event-type-availability": "function get_event_type_availability(event_type: string, start_time: string, end_time: string, timezone?: string);",
   "get-event": "function get_event(event_uuid: string);",
   "batch-event-invitees": "function batch_event_invitees(event_uri: string[], status?: \"active\" | \"canceled\", email?: string, count?: number, max_invitee_fetches?: number);",
   "list-event-invitees": "function list_event_invitees(event_uuid: string, status?: \"active\" | \"canceled\", email?: string, count?: number);",
@@ -453,6 +487,31 @@ async function fetchBatchEventInviteesResult(query: Record<string, unknown>, tim
 		normalizedQuery,
 		(eventUuid, pageToken, options) => fetchEventInviteesPage(apiKey, eventUuid, timeout, pageToken, options)
 	);
+}
+
+async function fetchEventTypeAvailabilityResult(query: Record<string, unknown>, timeout: number): Promise<any> {
+	const apiKey = process.env.CALENDLY_API_KEY;
+	if (!apiKey) throw new Error('CALENDLY_API_KEY environment variable is required');
+
+	const params = new URLSearchParams();
+	params.append('event_type', String(query.event_type_uri));
+	params.append('start_time', String(query.start_time));
+	params.append('end_time', String(query.end_time));
+	if (typeof query.timezone === 'string' && query.timezone.length > 0) {
+		params.append('timezone', query.timezone);
+	}
+
+	const response = await axios.get(
+		`https://api.calendly.com/event_type_available_times?${params.toString()}`,
+		{
+			headers: {
+				'Authorization': `Bearer ${apiKey}`,
+				'Content-Type': 'application/json',
+			},
+			timeout,
+		}
+	);
+	return shapeEventTypeAvailabilityResult(response.data, query as any);
 }
 
 async function fetchScheduledEventsWithInvitees(query: Record<string, unknown>, timeout: number): Promise<any> {
@@ -1017,6 +1076,72 @@ program
 		}
 	})
 	.addHelpText('after', () => '\nExample:\n  ' + "./calendly search-team --email person@example.com --organization-uri <ORG_URI> --count 25");
+
+program
+	.command("get-event-type-availability")
+	.summary("get-event-type-availability --event-type-uri <event-type-uri> --start-time <start-time:iso-8601> --end-time <end-time:iso-8601> [--timezone <timezone>] [--raw <json>]")
+	.description("Get available time slots for a specific event type")
+	.usage("--event-type-uri <event-type-uri> --start-time <start-time:iso-8601> --end-time <end-time:iso-8601> [--timezone <timezone>] [--raw <json>]")
+	.option('--raw <json>', 'Provide raw JSON arguments to the tool, bypassing flag parsing.')
+	.option("--event-type-uri <event-type-uri>", "Event type URI to check availability for")
+	.option("--start-time <start-time:iso-8601>", "Start time for availability window (ISO 8601 format)")
+	.option("--end-time <end-time:iso-8601>", "End time for availability window (ISO 8601 format)")
+	.option("--timezone <timezone>", "Optional IANA timezone (example: America/New_York)")
+	.alias("get_event_type_availability")
+	.action(async (cmdOpts) => {
+		const globalOptions = program.opts();
+		const timeout = globalOptions.timeout || 30000;
+		const rawArgs = cmdOpts.raw ? JSON.parse(cmdOpts.raw) : ({} as Record<string, unknown>);
+		const query = normalizeEventTypeAvailabilityQuery(cmdOpts, rawArgs);
+		let mcpResult: unknown;
+		let mcpErrorMessage: string | undefined;
+		try {
+			const runtime = await ensureRuntime();
+			const serverName = embeddedName;
+			const proxy = createServerProxy(runtime, serverName, {
+				initialSchemas: embeddedSchemas,
+			});
+			try {
+				const mcpArgs: Record<string, unknown> = {
+					event_type: query.event_type_uri,
+					start_time: query.start_time,
+					end_time: query.end_time,
+				};
+				if (query.timezone) {
+					mcpArgs.timezone = query.timezone;
+				}
+				const call = (proxy.getEventTypeAvailability as any)(mcpArgs);
+				mcpResult = await invokeWithTimeout(call, timeout);
+				const mcpRaw = createCallResult(mcpResult).raw as Record<string, unknown> | undefined;
+				if (mcpRaw && Array.isArray(mcpRaw.collection)) {
+					printResult(shapeEventTypeAvailabilityResult(mcpRaw, query), globalOptions.output ?? 'text');
+					return;
+				}
+			} catch (error) {
+				mcpErrorMessage = error instanceof Error ? error.message : String(error);
+			} finally {
+				await runtime.close(serverName).catch(() => {});
+			}
+		} catch (error) {
+			mcpErrorMessage = error instanceof Error ? error.message : String(error);
+		}
+		try {
+			const restResult = await fetchEventTypeAvailabilityResult(query, timeout);
+			printResult(restResult, globalOptions.output ?? 'text');
+		} catch (error) {
+			if (mcpResult !== undefined) {
+				printResult(mcpResult, globalOptions.output ?? 'text');
+				return;
+			}
+			let message = error instanceof Error ? error.message : String(error);
+			if (mcpErrorMessage) {
+				message = `${message} (MCP tool fallback failed: ${mcpErrorMessage})`;
+			}
+			console.error(`Error: ${message}`);
+			process.exit(1);
+		}
+	})
+	.addHelpText('after', () => '\nExample:\n  ' + "./calendly get-event-type-availability --event-type-uri https://api.calendly.com/event_types/ET_123 --start-time 2026-03-01T00:00:00Z --end-time 2026-03-02T00:00:00Z --timezone America/New_York");
 
 program
 	.command("get-event")

--- a/src/event-type-availability.test.ts
+++ b/src/event-type-availability.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from 'bun:test';
+import {
+	normalizeEventTypeAvailabilityQuery,
+	shapeEventTypeAvailabilityResult,
+} from './event-type-availability';
+
+describe('normalizeEventTypeAvailabilityQuery', () => {
+	test('normalizes required args from flags', () => {
+		const query = normalizeEventTypeAvailabilityQuery({
+			eventTypeUri: ' https://api.calendly.com/event_types/AAA ',
+			startTime: '2026-03-01T00:00:00Z',
+			endTime: '2026-03-02T00:00:00Z',
+		});
+		expect(query).toEqual({
+			event_type_uri: 'https://api.calendly.com/event_types/AAA',
+			event_type: 'https://api.calendly.com/event_types/AAA',
+			start_time: '2026-03-01T00:00:00Z',
+			end_time: '2026-03-02T00:00:00Z',
+		});
+	});
+
+	test('uses raw fallback and flag override', () => {
+		const query = normalizeEventTypeAvailabilityQuery(
+			{
+				startTime: '2026-03-03T00:00:00Z',
+				endTime: '2026-03-04T00:00:00Z',
+			},
+			{
+				event_type_uri: 'https://api.calendly.com/event_types/RAW',
+				start_time: '2026-03-01T00:00:00Z',
+				end_time: '2026-03-02T00:00:00Z',
+				timezone: 'America/New_York',
+			}
+		);
+		expect(query).toEqual({
+			event_type_uri: 'https://api.calendly.com/event_types/RAW',
+			event_type: 'https://api.calendly.com/event_types/RAW',
+			start_time: '2026-03-03T00:00:00Z',
+			end_time: '2026-03-04T00:00:00Z',
+			timezone: 'America/New_York',
+		});
+	});
+
+	test('rejects missing required args', () => {
+		expect(() => normalizeEventTypeAvailabilityQuery({})).toThrow('event_type_uri is required');
+		expect(() =>
+			normalizeEventTypeAvailabilityQuery({
+				eventTypeUri: 'https://api.calendly.com/event_types/AAA',
+				endTime: '2026-03-02T00:00:00Z',
+			})
+		).toThrow('start_time is required');
+		expect(() =>
+			normalizeEventTypeAvailabilityQuery({
+				eventTypeUri: 'https://api.calendly.com/event_types/AAA',
+				startTime: '2026-03-02T00:00:00Z',
+			})
+		).toThrow('end_time is required');
+	});
+
+	test('rejects invalid timestamps, inverted bounds, and oversized windows', () => {
+		expect(() =>
+			normalizeEventTypeAvailabilityQuery({
+				eventTypeUri: 'https://api.calendly.com/event_types/AAA',
+				startTime: '2026-03-01',
+				endTime: '2026-03-02T00:00:00Z',
+			})
+		).toThrow('start_time must be a valid ISO-8601 timestamp');
+		expect(() =>
+			normalizeEventTypeAvailabilityQuery({
+				eventTypeUri: 'https://api.calendly.com/event_types/AAA',
+				startTime: '2026-03-03T00:00:00Z',
+				endTime: '2026-03-02T00:00:00Z',
+			})
+		).toThrow('start_time must be less than or equal to end_time');
+		expect(() =>
+			normalizeEventTypeAvailabilityQuery({
+				eventTypeUri: 'https://api.calendly.com/event_types/AAA',
+				startTime: '2026-03-01T00:00:00Z',
+				endTime: '2026-03-10T00:00:00Z',
+			})
+		).toThrow('availability window cannot exceed 7 days');
+	});
+
+	test('validates optional timezone', () => {
+		expect(
+			normalizeEventTypeAvailabilityQuery({
+				eventTypeUri: 'https://api.calendly.com/event_types/AAA',
+				startTime: '2026-03-01T00:00:00Z',
+				endTime: '2026-03-02T00:00:00Z',
+				timezone: 'America/Los_Angeles',
+			}).timezone
+		).toBe('America/Los_Angeles');
+
+		expect(() =>
+			normalizeEventTypeAvailabilityQuery({
+				eventTypeUri: 'https://api.calendly.com/event_types/AAA',
+				startTime: '2026-03-01T00:00:00Z',
+				endTime: '2026-03-02T00:00:00Z',
+				timezone: 'Mars/Olympus',
+			})
+		).toThrow('timezone must be a valid IANA timezone');
+	});
+});
+
+describe('shapeEventTypeAvailabilityResult', () => {
+	test('normalizes slot collection and metadata', () => {
+		const shaped = shapeEventTypeAvailabilityResult(
+			{
+				collection: [
+					{
+						start_time: '2026-03-01T15:00:00Z',
+						end_time: '2026-03-01T15:30:00Z',
+						scheduling_url: 'https://calendly.com/example/slot-1',
+						status: 'available',
+						invitees_remaining: 1,
+					},
+					{
+						start_time: '2026-03-01T16:00:00Z',
+					},
+				],
+				pagination: {
+					next_page_token: null,
+				},
+			},
+			{
+				event_type_uri: 'https://api.calendly.com/event_types/AAA',
+				event_type: 'https://api.calendly.com/event_types/AAA',
+				start_time: '2026-03-01T00:00:00Z',
+				end_time: '2026-03-02T00:00:00Z',
+				timezone: 'America/New_York',
+			}
+		);
+
+		expect(shaped).toEqual({
+			query: {
+				event_type_uri: 'https://api.calendly.com/event_types/AAA',
+				start_time: '2026-03-01T00:00:00Z',
+				end_time: '2026-03-02T00:00:00Z',
+				timezone: 'America/New_York',
+			},
+			meta: {
+				slots: 2,
+			},
+			collection: [
+				{
+					start_time: '2026-03-01T15:00:00Z',
+					end_time: '2026-03-01T15:30:00Z',
+					scheduling_url: 'https://calendly.com/example/slot-1',
+					status: 'available',
+					invitees_remaining: 1,
+				},
+				{
+					start_time: '2026-03-01T16:00:00Z',
+					end_time: null,
+					scheduling_url: null,
+				},
+			],
+			pagination: {
+				next_page_token: null,
+			},
+		});
+	});
+});

--- a/src/event-type-availability.ts
+++ b/src/event-type-availability.ts
@@ -1,0 +1,155 @@
+const ISO_8601_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(?:Z|[+-]\d{2}:\d{2})$/;
+const ISO_8601_EXAMPLE = '2026-01-20T00:00:00Z';
+const TIMEZONE_EXAMPLE = 'America/New_York';
+const MAX_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+export type EventTypeAvailabilityCmdOptions = {
+	raw?: string;
+	eventTypeUri?: string;
+	startTime?: string;
+	endTime?: string;
+	timezone?: string;
+};
+
+export type EventTypeAvailabilityQuery = {
+	event_type_uri: string;
+	event_type: string;
+	start_time: string;
+	end_time: string;
+	timezone?: string;
+};
+
+function normalizeRequiredString(value: unknown, fieldName: string, requiredMessage: string): string {
+	if (value === undefined || value === null) {
+		throw new Error(requiredMessage);
+	}
+	if (typeof value !== 'string') {
+		throw new Error(`${fieldName} must be a non-empty string`);
+	}
+	const trimmed = value.trim();
+	if (!trimmed) {
+		throw new Error(`${fieldName} must be a non-empty string`);
+	}
+	return trimmed;
+}
+
+function normalizeIso8601Timestamp(value: unknown, fieldName: 'start_time' | 'end_time'): string {
+	const normalized = normalizeRequiredString(
+		value,
+		fieldName,
+		`${fieldName} is required (use --${fieldName.replace('_', '-')} or --raw {"${fieldName}":"..."})`
+	);
+	if (!ISO_8601_TIMESTAMP.test(normalized)) {
+		throw new Error(`${fieldName} must be a valid ISO-8601 timestamp (example: ${ISO_8601_EXAMPLE})`);
+	}
+	if (Number.isNaN(Date.parse(normalized))) {
+		throw new Error(`${fieldName} must be a valid ISO-8601 timestamp (example: ${ISO_8601_EXAMPLE})`);
+	}
+	return normalized;
+}
+
+function normalizeTimezone(value: unknown): string | undefined {
+	if (value === undefined || value === null) {
+		return undefined;
+	}
+	if (typeof value !== 'string') {
+		throw new Error(`timezone must be a valid IANA timezone (example: ${TIMEZONE_EXAMPLE})`);
+	}
+	const trimmed = value.trim();
+	if (!trimmed) {
+		throw new Error(`timezone must be a valid IANA timezone (example: ${TIMEZONE_EXAMPLE})`);
+	}
+	try {
+		new Intl.DateTimeFormat('en-US', { timeZone: trimmed }).format(new Date());
+	} catch {
+		throw new Error(`timezone must be a valid IANA timezone (example: ${TIMEZONE_EXAMPLE})`);
+	}
+	return trimmed;
+}
+
+function toOptionalFiniteNumber(value: unknown): number | undefined {
+	return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+export function normalizeEventTypeAvailabilityQuery(
+	cmdOpts: EventTypeAvailabilityCmdOptions,
+	defaults: Record<string, unknown> = {}
+): EventTypeAvailabilityQuery {
+	const eventTypeUri = normalizeRequiredString(
+		cmdOpts.eventTypeUri ?? defaults.event_type_uri ?? defaults.event_type,
+		'event_type_uri',
+		'event_type_uri is required (use --event-type-uri or --raw {"event_type_uri":"..."})'
+	);
+	const startTime = normalizeIso8601Timestamp(cmdOpts.startTime ?? defaults.start_time, 'start_time');
+	const endTime = normalizeIso8601Timestamp(cmdOpts.endTime ?? defaults.end_time, 'end_time');
+	const timezone = normalizeTimezone(cmdOpts.timezone ?? defaults.timezone);
+
+	const startMs = Date.parse(startTime);
+	const endMs = Date.parse(endTime);
+	if (startMs > endMs) {
+		throw new Error('start_time must be less than or equal to end_time');
+	}
+	if (endMs - startMs > MAX_WINDOW_MS) {
+		throw new Error('availability window cannot exceed 7 days');
+	}
+
+	return {
+		event_type_uri: eventTypeUri,
+		event_type: eventTypeUri,
+		start_time: startTime,
+		end_time: endTime,
+		...(timezone ? { timezone } : {}),
+	};
+}
+
+type AvailabilitySlot = {
+	start_time: string;
+	end_time: string | null;
+	scheduling_url: string | null;
+	status?: string;
+	invitees_remaining?: number;
+};
+
+function normalizeAvailabilitySlot(slot: unknown): AvailabilitySlot {
+	const record = slot && typeof slot === 'object' ? (slot as Record<string, unknown>) : {};
+	const startTime = typeof record.start_time === 'string' ? record.start_time : '';
+	const endTime = typeof record.end_time === 'string' ? record.end_time : null;
+	const schedulingUrl = typeof record.scheduling_url === 'string' ? record.scheduling_url : null;
+	const status = typeof record.status === 'string' ? record.status : undefined;
+	const inviteesRemaining = toOptionalFiniteNumber(record.invitees_remaining);
+	return {
+		start_time: startTime,
+		end_time: endTime,
+		scheduling_url: schedulingUrl,
+		...(status ? { status } : {}),
+		...(inviteesRemaining !== undefined ? { invitees_remaining: inviteesRemaining } : {}),
+	};
+}
+
+export function shapeEventTypeAvailabilityResult(
+	result: unknown,
+	query: EventTypeAvailabilityQuery
+): Record<string, unknown> {
+	const response = result && typeof result === 'object' ? (result as Record<string, unknown>) : {};
+	const collectionRaw = Array.isArray(response.collection) ? response.collection : [];
+	const collection = collectionRaw.map((slot) => normalizeAvailabilitySlot(slot));
+	const querySummary: Record<string, unknown> = {
+		event_type_uri: query.event_type_uri,
+		start_time: query.start_time,
+		end_time: query.end_time,
+	};
+	if (query.timezone) {
+		querySummary.timezone = query.timezone;
+	}
+	const shaped: Record<string, unknown> = {
+		query: querySummary,
+		meta: {
+			slots: collection.length,
+		},
+		collection,
+	};
+	if (response.pagination && typeof response.pagination === 'object') {
+		shaped.pagination = response.pagination;
+	}
+	return shaped;
+}


### PR DESCRIPTION
## What
- Add `get-event-type-availability` command to `calendly` with required `--event-type-uri`, `--start-time`, `--end-time`, and optional `--timezone`.
- Validate and normalize arguments (ISO-8601 timestamps, start/end ordering, max 7-day window, timezone validation, raw JSON compatibility) via new helper module.
- Implement MCP-first execution with direct Calendly REST fallback (`GET /event_type_available_times`) using existing auth/timeout patterns.
- Shape success responses into stable JSON-friendly output (`query`, `meta`, `collection`) for consistent CLI output modes.
- Update embedded help metadata so top-level `--help` includes the new command.
- Update `README.md` and `SKILL.md` with usage and validation examples.
- Add tests for parsing/validation and success-path shaping.

## Why
- Closes #25.
- Users need a direct way to fetch event-type availability windows and propose concrete times without sending a generic booking link.
- Current npm-published `calendly-mcp-server` is still `1.0.0`; this preserves forward compatibility by preferring MCP when available while remaining functional now via REST fallback.

## Tests
- `bun test`
- `./calendly --help`
- `./calendly get-event-type-availability --help`
- `codex review --base main` (no P0-P2 findings)

## AI Assistance
- Used: Yes (`codex` CLI)
- Testing level: Local automated tests + CLI help checks + automated code review
- Prompt/session log link: N/A (local Codex CLI session, no shareable external link)
- I understand this code.
