### PR TITLE
feat(cli): add list-event-types command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Moltbot skill for Calendly integration. List events, check availability, manage 
 - **Invitee Management**: View event invitees
 - **Organization**: List organization memberships
 
-> **Note:** This CLI now includes `get-event-type-availability` with strict argument validation and REST fallback support. Other Scheduling API features (`list-event-types`, `schedule-event`) still depend on calendly-mcp-server v2.0.0 being published to npm.
+> **Note:** This CLI now includes `list-event-types` and `get-event-type-availability` with strict argument validation and MCP-first + REST fallback support. `schedule-event` still depends on calendly-mcp-server v2.0.0 being published to npm.
 
 ## Installation
 
@@ -119,6 +119,19 @@ Validation rules:
 - availability window must be 7 days or less.
 - `--timezone` is optional and must be a valid IANA timezone.
 
+### List Event Types
+
+```bash
+./calendly list-event-types \
+  --organization-uri "https://api.calendly.com/organizations/<ORG_UUID>" \
+  --count 20 \
+  -o json
+```
+
+Validation rules:
+- at least one scope is required: `--user-uri` or `--organization-uri` (same in `--raw` mode)
+- `--count` is optional; when set, it must be an integer between 1 and 100
+
 ### Get Event Details
 
 ```bash
@@ -173,6 +186,7 @@ Signing secret handling guidance:
 - `list-events` - List scheduled events (`--include-invitees` for expand + bounded fallback invitee hydration)
 - `list-events-with-invitees` - Compatibility alias for include-invitees path
 - `get-event` - Get event details
+- `list-event-types` - List available event types for scheduling (requires at least one of `--user-uri` or `--organization-uri`)
 - `get-event-type-availability` - Get available time slots for a specific event type
 - `cancel-event` - Cancel an event
 - `list-event-invitees` - List invitees for a specific event
@@ -219,11 +233,10 @@ Once calendly-mcp-server v2.0.0 is published to npm (adds the remaining Scheduli
 MCPORTER_CONFIG=./mcporter.json npx mcporter@latest generate-cli --server calendly --output calendly
 
 # Verify new commands appear
-./calendly --help | grep -E "list-event-types|schedule-event"
+./calendly --help | grep -E "schedule-event"
 ```
 
 The remaining v2.0 Scheduling API commands will add:
-- `list-event-types` - List available event types for scheduling
 - `schedule-event` - Schedule meetings programmatically
 
 **Requires:** Paid Calendly plan (Standard or higher)

--- a/SKILL.md
+++ b/SKILL.md
@@ -7,7 +7,7 @@ description: Calendly scheduling integration. List events, check availability, m
 
 Interact with Calendly scheduling via MCP-generated CLI.
 
-> **Note:** This CLI includes `get-event-type-availability` with strict input validation and REST fallback. Remaining Scheduling API features (`list-event-types`, `schedule-event`) still require calendly-mcp-server v2.0.0 on npm.
+> **Note:** This CLI includes `list-event-types` and `get-event-type-availability` with strict input validation and MCP-first + REST fallback. `schedule-event` still requires calendly-mcp-server v2.0.0 on npm.
 
 ## Quick Start
 
@@ -37,6 +37,7 @@ calendly cancel-event --event-uuid <UUID> --reason "Rescheduling needed"
 - `list-events` - List scheduled events (requires --user-uri); add `--include-invitees` for expand + bounded fallback invitee hydration
 - `list-events-with-invitees` - Compatibility alias for include-invitees path
 - `get-event` - Get event details (requires --event-uuid)
+- `list-event-types` - List schedulable event types (requires `--user-uri` or `--organization-uri`; optional `--count`)
 - `get-event-type-availability` - Get available slots for an event type (`--event-type-uri`, `--start-time`, `--end-time`; optional `--timezone`)
 - `cancel-event` - Cancel an event (requires --event-uuid, optional --reason)
 
@@ -114,6 +115,12 @@ calendly get-event-type-availability \
   --timezone "America/New_York" \
   -o json
 
+# List event types
+calendly list-event-types \
+  --organization-uri "https://api.calendly.com/organizations/<ORG_UUID>" \
+  --count 20 \
+  -o json
+
 # Batch invitee lookup for multiple events
 calendly batch-event-invitees \
   --event-uri "https://api.calendly.com/scheduled_events/<EVENT_UUID_1>" \
@@ -159,10 +166,7 @@ Once calendly-mcp-server v2.0.0 is published, these additional commands will be 
 
 ### Scheduling Workflow
 ```bash
-# 1. List available event types
-calendly list-event-types
-
-# 2. Schedule a meeting (requires paid Calendly plan)
+# 1. Schedule a meeting (requires paid Calendly plan)
 calendly schedule-event \
   --event-type "<EVENT_TYPE_URI>" \
   --start-time "2026-01-25T19:00:00Z" \
@@ -172,7 +176,7 @@ calendly schedule-event \
 ```
 
 **Scheduling API Requirements:**
-- calendly-mcp-server v2.0.0+ (unreleased as of 2026-01-21)
+- calendly-mcp-server v2.0.0+ (unreleased as of 2026-02-23)
 - Paid Calendly plan (Standard or higher)
 
 To upgrade when v2.0 is published:
@@ -225,5 +229,5 @@ calendly list-events --user-uri "<URI>" --min-start-time "$(date -u +%Y-%m-%dT%H
 ---
 
 **Generated:** 2026-01-20  
-**Updated:** 2026-02-23 (Added get-event-type-availability command with validation + REST fallback)
+**Updated:** 2026-02-23 (Added list-event-types command plus validation + MCP-first REST fallback)
 **Source:** meAmitPatil/calendly-mcp-server via mcporter

--- a/calendly
+++ b/calendly
@@ -11,6 +11,11 @@ import { normalizeListEventsQuery } from './src/list-events-query';
 import { fetchBatchEventInvitees, normalizeBatchEventInviteesQuery } from './src/batch-event-invitees';
 import { normalizeEventTypeAvailabilityQuery, shapeEventTypeAvailabilityResult } from './src/event-type-availability';
 import {
+	normalizeListEventTypesQuery,
+	shapeListEventTypesResult,
+	toListEventTypesMcpArgs,
+} from './src/list-event-types';
+import {
 	eventInviteeCount,
 	extractInviteePaginationMeta,
 	hydrateMissingInvitees,
@@ -126,6 +131,24 @@ const embeddedSchemas = {
       "count": {
         "type": "number",
         "description": "Number of events to return (default 20, max 100)"
+      }
+    },
+    "required": []
+  },
+  "list_event_types": {
+    "type": "object",
+    "properties": {
+      "user": {
+        "type": "string",
+        "description": "URI of the user whose event types to list"
+      },
+      "organization": {
+        "type": "string",
+        "description": "URI of the organization to filter event types"
+      },
+      "count": {
+        "type": "number",
+        "description": "Number of event types to return (default 20, max 100)"
       }
     },
     "required": []
@@ -288,6 +311,12 @@ const generatorTools = [
     "flags": "--email <email> [--min-start-time <min-start-time:iso-8601>] [--max-start-time <max-start-time:iso-8601>] [--status <status:active|canceled>] [--organization-uri <organization-uri>] [--count <count:number>] [--max-membership-pages <max-membership-pages:number>]"
   },
   {
+    "name": "list-event-types",
+    "description": "List available event types for scheduling meetings",
+    "usage": "list-event-types (--user-uri <user-uri> | --organization-uri <organization-uri>) [--count <count:number>] [--raw <json>]",
+    "flags": "(--user-uri <user-uri> | --organization-uri <organization-uri>) [--count <count:number>] [--raw <json>]"
+  },
+  {
     "name": "get-event-type-availability",
     "description": "Get available time slots for a specific event type",
     "usage": "get-event-type-availability --event-type-uri <event-type-uri> --start-time <start-time:iso-8601> --end-time <end-time:iso-8601> [--timezone <timezone>] [--raw <json>]",
@@ -407,6 +436,7 @@ const commandSignatures: Record<string, string> = {
   "list-events-with-invitees": "function list_events_with_invitees(user_uri?: string, organization_uri?: string, status?: \"active\" | \"canceled\", max_start_time?: string, min_start_time?: string, count?: number, hydrate_invitees?: boolean, max_invitee_fetches?: number);",
   "search-invitees": "function search_invitees(email: string, user_uri?: string, organization_uri?: string, status?: \"active\" | \"canceled\", min_start_time?: string, max_start_time?: string, page_size?: number, max_pages?: number);",
   "search-team": "function search_team(email: string, min_start_time?: string, max_start_time?: string, status?: \"active\" | \"canceled\", organization_uri?: string, count?: number, max_membership_pages?: number);",
+  "list-event-types": "function list_event_types(user?: string, organization?: string, count?: number);",
   "get-event-type-availability": "function get_event_type_availability(event_type: string, start_time: string, end_time: string, timezone?: string);",
   "get-event": "function get_event(event_uuid: string);",
   "batch-event-invitees": "function batch_event_invitees(event_uri: string[], status?: \"active\" | \"canceled\", email?: string, count?: number, max_invitee_fetches?: number);",
@@ -487,6 +517,31 @@ async function fetchBatchEventInviteesResult(query: Record<string, unknown>, tim
 		normalizedQuery,
 		(eventUuid, pageToken, options) => fetchEventInviteesPage(apiKey, eventUuid, timeout, pageToken, options)
 	);
+}
+
+async function fetchListEventTypesResult(query: Record<string, unknown>, timeout: number): Promise<any> {
+	const apiKey = process.env.CALENDLY_API_KEY;
+	if (!apiKey) throw new Error('CALENDLY_API_KEY environment variable is required');
+
+	const params = new URLSearchParams();
+	if (typeof query.user_uri === 'string' && query.user_uri.length > 0) {
+		params.append('user', query.user_uri);
+	}
+	if (typeof query.organization_uri === 'string' && query.organization_uri.length > 0) {
+		params.append('organization', query.organization_uri);
+	}
+	if (typeof query.count === 'number' && Number.isFinite(query.count)) {
+		params.append('count', String(query.count));
+	}
+
+	const response = await axios.get(`https://api.calendly.com/event_types?${params.toString()}`, {
+		headers: {
+			'Authorization': `Bearer ${apiKey}`,
+			'Content-Type': 'application/json',
+		},
+		timeout,
+	});
+	return shapeListEventTypesResult(response.data, query);
 }
 
 async function fetchEventTypeAvailabilityResult(query: Record<string, unknown>, timeout: number): Promise<any> {
@@ -1076,6 +1131,63 @@ program
 		}
 	})
 	.addHelpText('after', () => '\nExample:\n  ' + "./calendly search-team --email person@example.com --organization-uri <ORG_URI> --count 25");
+
+program
+	.command("list-event-types")
+	.summary("list-event-types (--user-uri <user-uri> | --organization-uri <organization-uri>) [--count <count:number>] [--raw <json>]")
+	.description("List available event types for scheduling meetings")
+	.usage("(--user-uri <user-uri> | --organization-uri <organization-uri>) [--count <count:number>] [--raw <json>]")
+	.option('--raw <json>', 'Provide raw JSON arguments to the tool, bypassing flag parsing.')
+	.option("--user-uri <user-uri>", "URI of the user whose event types to list")
+	.option("--organization-uri <organization-uri>", "URI of the organization to filter event types")
+	.option("--count <count:number>", "Number of event types to return (default 20, max 100) (example: 20)", (value) => parseFloat(value))
+	.alias("list_event_types")
+	.action(async (cmdOpts) => {
+		const globalOptions = program.opts();
+		const timeout = globalOptions.timeout || 30000;
+		const rawArgs = cmdOpts.raw ? JSON.parse(cmdOpts.raw) : ({} as Record<string, unknown>);
+		const query = normalizeListEventTypesQuery(cmdOpts, rawArgs);
+		let mcpResult: unknown;
+		let mcpErrorMessage: string | undefined;
+		try {
+			const runtime = await ensureRuntime();
+			const serverName = embeddedName;
+			const proxy = createServerProxy(runtime, serverName, {
+				initialSchemas: embeddedSchemas,
+			});
+			try {
+				const call = (proxy.listEventTypes as any)(toListEventTypesMcpArgs(query));
+				mcpResult = await invokeWithTimeout(call, timeout);
+				const mcpRaw = createCallResult(mcpResult).raw as Record<string, unknown> | undefined;
+				if (mcpRaw && Array.isArray(mcpRaw.collection)) {
+					printResult(shapeListEventTypesResult(mcpRaw, query), globalOptions.output ?? 'text');
+					return;
+				}
+			} catch (error) {
+				mcpErrorMessage = error instanceof Error ? error.message : String(error);
+			} finally {
+				await runtime.close(serverName).catch(() => {});
+			}
+		} catch (error) {
+			mcpErrorMessage = error instanceof Error ? error.message : String(error);
+		}
+		try {
+			const restResult = await fetchListEventTypesResult(query, timeout);
+			printResult(restResult, globalOptions.output ?? 'text');
+		} catch (error) {
+			if (mcpResult !== undefined) {
+				printResult(mcpResult, globalOptions.output ?? 'text');
+				return;
+			}
+			let message = error instanceof Error ? error.message : String(error);
+			if (mcpErrorMessage) {
+				message = `${message} (MCP tool fallback failed: ${mcpErrorMessage})`;
+			}
+			console.error(`Error: ${message}`);
+			process.exit(1);
+		}
+	})
+	.addHelpText('after', () => '\nExample:\n  ' + "./calendly list-event-types --organization-uri https://api.calendly.com/organizations/ORG_123 --count 20");
 
 program
 	.command("get-event-type-availability")

--- a/src/list-event-types.test.ts
+++ b/src/list-event-types.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from 'bun:test';
+import {
+	normalizeListEventTypesQuery,
+	shapeListEventTypesResult,
+	toListEventTypesMcpArgs,
+} from './list-event-types';
+
+describe('normalizeListEventTypesQuery', () => {
+	test('normalizes scope and count from flags', () => {
+		const query = normalizeListEventTypesQuery({
+			userUri: ' https://api.calendly.com/users/U1 ',
+			count: 25,
+		});
+
+		expect(query).toEqual({
+			user_uri: 'https://api.calendly.com/users/U1',
+			count: 25,
+		});
+	});
+
+	test('supports raw fallbacks including upstream key names', () => {
+		const query = normalizeListEventTypesQuery(
+			{
+				organizationUri: ' https://api.calendly.com/organizations/ORG_FLAG ',
+			},
+			{
+				user: 'https://api.calendly.com/users/U_RAW',
+				organization: 'https://api.calendly.com/organizations/ORG_RAW',
+				count: 40,
+			}
+		);
+
+		expect(query).toEqual({
+			user_uri: 'https://api.calendly.com/users/U_RAW',
+			organization_uri: 'https://api.calendly.com/organizations/ORG_FLAG',
+			count: 40,
+		});
+	});
+
+	test('rejects missing scope filters', () => {
+		expect(() => normalizeListEventTypesQuery({})).toThrow('either user_uri or organization_uri is required');
+	});
+
+	test('rejects invalid count', () => {
+		expect(() =>
+			normalizeListEventTypesQuery(
+				{
+					userUri: 'https://api.calendly.com/users/U1',
+				},
+				{ count: 'bad' }
+			)
+		).toThrow('count must be an integer between 1 and 100');
+
+		expect(() =>
+			normalizeListEventTypesQuery({
+				userUri: 'https://api.calendly.com/users/U1',
+				count: 101,
+			})
+		).toThrow('count must be an integer between 1 and 100');
+	});
+});
+
+describe('toListEventTypesMcpArgs', () => {
+	test('maps normalized query to MCP argument names', () => {
+		expect(
+			toListEventTypesMcpArgs({
+				user_uri: 'https://api.calendly.com/users/U1',
+				organization_uri: 'https://api.calendly.com/organizations/O1',
+				count: 10,
+			})
+		).toEqual({
+			user: 'https://api.calendly.com/users/U1',
+			organization: 'https://api.calendly.com/organizations/O1',
+			count: 10,
+		});
+	});
+});
+
+describe('shapeListEventTypesResult', () => {
+	test('returns normalized query/meta and collection', () => {
+		const shaped = shapeListEventTypesResult(
+			{
+				collection: [
+					{
+						uri: 'https://api.calendly.com/event_types/E1',
+						name: 'Demo',
+						duration: 30,
+					},
+					{
+						uri: 'https://api.calendly.com/event_types/E2',
+						name: 'Kickoff',
+						duration: 60,
+					},
+				],
+				pagination: {
+					next_page_token: null,
+				},
+			},
+			{
+				user_uri: 'https://api.calendly.com/users/U1',
+				count: 2,
+			}
+		);
+
+		expect(shaped).toEqual({
+			query: {
+				user_uri: 'https://api.calendly.com/users/U1',
+				count: 2,
+			},
+			meta: {
+				event_types: 2,
+			},
+			collection: [
+				{
+					uri: 'https://api.calendly.com/event_types/E1',
+					name: 'Demo',
+					duration: 30,
+				},
+				{
+					uri: 'https://api.calendly.com/event_types/E2',
+					name: 'Kickoff',
+					duration: 60,
+				},
+			],
+			pagination: {
+				next_page_token: null,
+			},
+		});
+	});
+});

--- a/src/list-event-types.ts
+++ b/src/list-event-types.ts
@@ -1,0 +1,107 @@
+export type ListEventTypesCmdOptions = {
+	raw?: string;
+	userUri?: string;
+	organizationUri?: string;
+	count?: number;
+};
+
+export type ListEventTypesQuery = {
+	user_uri?: string;
+	organization_uri?: string;
+	count?: number;
+};
+
+function normalizeOptionalString(value: unknown, fieldName: string): string | undefined {
+	if (value === undefined || value === null) {
+		return undefined;
+	}
+	if (typeof value !== 'string') {
+		throw new Error(`${fieldName} must be a non-empty string`);
+	}
+	const trimmed = value.trim();
+	if (!trimmed) {
+		throw new Error(`${fieldName} must be a non-empty string`);
+	}
+	return trimmed;
+}
+
+function normalizeCount(value: unknown): number | undefined {
+	if (value === undefined || value === null) {
+		return undefined;
+	}
+
+	const numeric =
+		typeof value === 'number'
+			? value
+			: typeof value === 'string' && value.trim()
+				? Number(value)
+				: Number.NaN;
+
+	if (!Number.isFinite(numeric) || !Number.isInteger(numeric)) {
+		throw new Error('count must be an integer between 1 and 100');
+	}
+	if (numeric < 1 || numeric > 100) {
+		throw new Error('count must be an integer between 1 and 100');
+	}
+	return numeric;
+}
+
+export function normalizeListEventTypesQuery(
+	cmdOpts: ListEventTypesCmdOptions,
+	defaults: Record<string, unknown> = {}
+): ListEventTypesQuery {
+	const userUri = normalizeOptionalString(cmdOpts.userUri ?? defaults.user_uri ?? defaults.user, 'user_uri');
+	const organizationUri = normalizeOptionalString(
+		cmdOpts.organizationUri ?? defaults.organization_uri ?? defaults.organization,
+		'organization_uri'
+	);
+	const count = normalizeCount(cmdOpts.count ?? defaults.count);
+
+	if (!userUri && !organizationUri) {
+		throw new Error(
+			'either user_uri or organization_uri is required (use --user-uri, --organization-uri, or --raw {"user_uri":"..."} / {"organization_uri":"..."})'
+		);
+	}
+
+	return {
+		...(userUri ? { user_uri: userUri } : {}),
+		...(organizationUri ? { organization_uri: organizationUri } : {}),
+		...(count !== undefined ? { count } : {}),
+	};
+}
+
+export function toListEventTypesMcpArgs(query: ListEventTypesQuery): Record<string, unknown> {
+	return {
+		...(query.user_uri ? { user: query.user_uri } : {}),
+		...(query.organization_uri ? { organization: query.organization_uri } : {}),
+		...(query.count !== undefined ? { count: query.count } : {}),
+	};
+}
+
+function toRecord(value: unknown): Record<string, unknown> {
+	return value && typeof value === 'object' ? { ...(value as Record<string, unknown>) } : {};
+}
+
+export function shapeListEventTypesResult(
+	result: unknown,
+	query: ListEventTypesQuery
+): Record<string, unknown> {
+	const response = toRecord(result);
+	const collectionRaw = Array.isArray(response.collection) ? response.collection : [];
+	const collection = collectionRaw.map((item) => toRecord(item));
+	const shaped: Record<string, unknown> = {
+		query: {
+			...(query.user_uri ? { user_uri: query.user_uri } : {}),
+			...(query.organization_uri ? { organization_uri: query.organization_uri } : {}),
+			...(query.count !== undefined ? { count: query.count } : {}),
+		},
+		meta: {
+			event_types: collection.length,
+		},
+		collection,
+	};
+	if (response.pagination && typeof response.pagination === 'object') {
+		shaped.pagination = response.pagination;
+	}
+	return shaped;
+}


### PR DESCRIPTION
## What
- add `list-event-types` command with validation requiring at least one of `--user-uri` or `--organization-uri`
- add optional `--count` validation (`1..100` integer)
- implement MCP-first execution via `list_event_types` with mapped args (`user`, `organization`, `count`)
- implement REST fallback to `GET /event_types` with normalized shaped output
- add unit tests in `src/list-event-types.test.ts`
- update docs in `README.md` and `SKILL.md`

## Why
- implement issue #22 and keep scheduling workflow usable while upstream `calendly-mcp-server` packaging is still catching up

Closes #22

## Tests
- `bun test`
- `./calendly --help`
- `./calendly list-event-types --help`
- `./calendly list-event-types` (validation path)

## AI Assistance
- Used: yes (`codex` for implementation and review)
- Testing level: local unit tests + CLI help/validation checks
- Prompt/session log: local Codex CLI session `019c885b-c5f6-7152-aa0f-34494d957288`
- I understand this code.