### PR TITLE
feat(cli): add get-event-type command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Moltbot skill for Calendly integration. List events, check availability, manage 
 - **Invitee Management**: View event invitees
 - **Organization**: List organization memberships
 
-> **Note:** This CLI now includes `list-event-types` and `get-event-type-availability` with strict argument validation and MCP-first + REST fallback support. `schedule-event` still depends on calendly-mcp-server v2.0.0 being published to npm.
+> **Note:** This CLI now includes `list-event-types`, `get-event-type`, and `get-event-type-availability` with strict argument validation and MCP-first + REST fallback support. `schedule-event` still depends on calendly-mcp-server v2.0.0 being published to npm.
 
 ## Installation
 
@@ -132,6 +132,17 @@ Validation rules:
 - at least one scope is required: `--user-uri` or `--organization-uri` (same in `--raw` mode)
 - `--count` is optional; when set, it must be an integer between 1 and 100
 
+### Get Event Type Details
+
+```bash
+./calendly get-event-type \
+  --event-type-uri "https://api.calendly.com/event_types/<EVENT_TYPE_UUID>" \
+  -o json
+```
+
+Validation rules:
+- `--event-type-uri` is required (also enforced for `--raw` JSON).
+
 ### Get Event Details
 
 ```bash
@@ -187,6 +198,7 @@ Signing secret handling guidance:
 - `list-events-with-invitees` - Compatibility alias for include-invitees path
 - `get-event` - Get event details
 - `list-event-types` - List available event types for scheduling (requires at least one of `--user-uri` or `--organization-uri`)
+- `get-event-type` - Get details for a specific event type (requires `--event-type-uri`)
 - `get-event-type-availability` - Get available time slots for a specific event type
 - `cancel-event` - Cancel an event
 - `list-event-invitees` - List invitees for a specific event

--- a/SKILL.md
+++ b/SKILL.md
@@ -7,7 +7,7 @@ description: Calendly scheduling integration. List events, check availability, m
 
 Interact with Calendly scheduling via MCP-generated CLI.
 
-> **Note:** This CLI includes `list-event-types` and `get-event-type-availability` with strict input validation and MCP-first + REST fallback. `schedule-event` still requires calendly-mcp-server v2.0.0 on npm.
+> **Note:** This CLI includes `list-event-types`, `get-event-type`, and `get-event-type-availability` with strict input validation and MCP-first + REST fallback. `schedule-event` still requires calendly-mcp-server v2.0.0 on npm.
 
 ## Quick Start
 
@@ -38,6 +38,7 @@ calendly cancel-event --event-uuid <UUID> --reason "Rescheduling needed"
 - `list-events-with-invitees` - Compatibility alias for include-invitees path
 - `get-event` - Get event details (requires --event-uuid)
 - `list-event-types` - List schedulable event types (requires `--user-uri` or `--organization-uri`; optional `--count`)
+- `get-event-type` - Get event type details (requires `--event-type-uri`)
 - `get-event-type-availability` - Get available slots for an event type (`--event-type-uri`, `--start-time`, `--end-time`; optional `--timezone`)
 - `cancel-event` - Cancel an event (requires --event-uuid, optional --reason)
 
@@ -105,6 +106,11 @@ calendly list-events \
 # Get event details
 calendly get-event \
   --event-uuid "<EVENT_UUID>" \
+  -o json
+
+# Get event type details
+calendly get-event-type \
+  --event-type-uri "https://api.calendly.com/event_types/<EVENT_TYPE_UUID>" \
   -o json
 
 # Get event type availability
@@ -229,5 +235,5 @@ calendly list-events --user-uri "<URI>" --min-start-time "$(date -u +%Y-%m-%dT%H
 ---
 
 **Generated:** 2026-01-20  
-**Updated:** 2026-02-23 (Added list-event-types command plus validation + MCP-first REST fallback)
+**Updated:** 2026-02-23 (Added get-event-type command plus validation + MCP-first REST fallback)
 **Source:** meAmitPatil/calendly-mcp-server via mcporter

--- a/calendly
+++ b/calendly
@@ -10,6 +10,7 @@ import { normalizeDateRange } from './src/date-range';
 import { normalizeListEventsQuery } from './src/list-events-query';
 import { fetchBatchEventInvitees, normalizeBatchEventInviteesQuery } from './src/batch-event-invitees';
 import { normalizeEventTypeAvailabilityQuery, shapeEventTypeAvailabilityResult } from './src/event-type-availability';
+import { extractEventTypeUuid, normalizeGetEventTypeQuery, shapeGetEventTypeResult } from './src/get-event-type';
 import {
 	normalizeListEventTypesQuery,
 	shapeListEventTypesResult,
@@ -179,6 +180,18 @@ const embeddedSchemas = {
       "end_time"
     ]
   },
+  "get_event_type": {
+    "type": "object",
+    "properties": {
+      "event_type": {
+        "type": "string",
+        "description": "URI of the event type to retrieve"
+      }
+    },
+    "required": [
+      "event_type"
+    ]
+  },
   "get_event": {
     "type": "object",
     "properties": {
@@ -317,6 +330,12 @@ const generatorTools = [
     "flags": "(--user-uri <user-uri> | --organization-uri <organization-uri>) [--count <count:number>] [--raw <json>]"
   },
   {
+    "name": "get-event-type",
+    "description": "Get details of a specific event type",
+    "usage": "get-event-type --event-type-uri <event-type-uri> [--raw <json>]",
+    "flags": "--event-type-uri <event-type-uri> [--raw <json>]"
+  },
+  {
     "name": "get-event-type-availability",
     "description": "Get available time slots for a specific event type",
     "usage": "get-event-type-availability --event-type-uri <event-type-uri> --start-time <start-time:iso-8601> --end-time <end-time:iso-8601> [--timezone <timezone>] [--raw <json>]",
@@ -437,6 +456,7 @@ const commandSignatures: Record<string, string> = {
   "search-invitees": "function search_invitees(email: string, user_uri?: string, organization_uri?: string, status?: \"active\" | \"canceled\", min_start_time?: string, max_start_time?: string, page_size?: number, max_pages?: number);",
   "search-team": "function search_team(email: string, min_start_time?: string, max_start_time?: string, status?: \"active\" | \"canceled\", organization_uri?: string, count?: number, max_membership_pages?: number);",
   "list-event-types": "function list_event_types(user?: string, organization?: string, count?: number);",
+  "get-event-type": "function get_event_type(event_type: string);",
   "get-event-type-availability": "function get_event_type_availability(event_type: string, start_time: string, end_time: string, timezone?: string);",
   "get-event": "function get_event(event_uuid: string);",
   "batch-event-invitees": "function batch_event_invitees(event_uri: string[], status?: \"active\" | \"canceled\", email?: string, count?: number, max_invitee_fetches?: number);",
@@ -542,6 +562,21 @@ async function fetchListEventTypesResult(query: Record<string, unknown>, timeout
 		timeout,
 	});
 	return shapeListEventTypesResult(response.data, query);
+}
+
+async function fetchGetEventTypeResult(query: Record<string, unknown>, timeout: number): Promise<any> {
+	const apiKey = process.env.CALENDLY_API_KEY;
+	if (!apiKey) throw new Error('CALENDLY_API_KEY environment variable is required');
+
+	const eventTypeUuid = extractEventTypeUuid(String(query.event_type_uri));
+	const response = await axios.get(`https://api.calendly.com/event_types/${encodeURIComponent(eventTypeUuid)}`, {
+		headers: {
+			'Authorization': `Bearer ${apiKey}`,
+			'Content-Type': 'application/json',
+		},
+		timeout,
+	});
+	return shapeGetEventTypeResult(response.data, query as any);
 }
 
 async function fetchEventTypeAvailabilityResult(query: Record<string, unknown>, timeout: number): Promise<any> {
@@ -1188,6 +1223,67 @@ program
 		}
 	})
 	.addHelpText('after', () => '\nExample:\n  ' + "./calendly list-event-types --organization-uri https://api.calendly.com/organizations/ORG_123 --count 20");
+
+program
+	.command("get-event-type")
+	.summary("get-event-type --event-type-uri <event-type-uri> [--raw <json>]")
+	.description("Get details of a specific event type")
+	.usage("--event-type-uri <event-type-uri> [--raw <json>]")
+	.option('--raw <json>', 'Provide raw JSON arguments to the tool, bypassing flag parsing.')
+	.option("--event-type-uri <event-type-uri>", "URI of the event type to retrieve")
+	.alias("get_event_type")
+	.action(async (cmdOpts) => {
+		const globalOptions = program.opts();
+		const timeout = globalOptions.timeout || 30000;
+		const rawArgs = cmdOpts.raw ? JSON.parse(cmdOpts.raw) : ({} as Record<string, unknown>);
+		const query = normalizeGetEventTypeQuery(cmdOpts, rawArgs);
+		let mcpResult: unknown;
+		let mcpErrorMessage: string | undefined;
+		try {
+			const runtime = await ensureRuntime();
+			const serverName = embeddedName;
+			const proxy = createServerProxy(runtime, serverName, {
+				initialSchemas: embeddedSchemas,
+			});
+			try {
+				const call = (proxy.getEventType as any)({
+					event_type: query.event_type_uri,
+				});
+				mcpResult = await invokeWithTimeout(call, timeout);
+				const mcpRaw = createCallResult(mcpResult).raw as Record<string, unknown> | undefined;
+				if (mcpRaw) {
+					const shaped = shapeGetEventTypeResult(mcpRaw, query);
+					const found = Boolean((shaped.meta as Record<string, unknown> | undefined)?.found);
+					if (found) {
+						printResult(shaped, globalOptions.output ?? 'text');
+						return;
+					}
+				}
+			} catch (error) {
+				mcpErrorMessage = error instanceof Error ? error.message : String(error);
+			} finally {
+				await runtime.close(serverName).catch(() => {});
+			}
+		} catch (error) {
+			mcpErrorMessage = error instanceof Error ? error.message : String(error);
+		}
+		try {
+			const restResult = await fetchGetEventTypeResult(query, timeout);
+			printResult(restResult, globalOptions.output ?? 'text');
+		} catch (error) {
+			if (mcpResult !== undefined) {
+				printResult(mcpResult, globalOptions.output ?? 'text');
+				return;
+			}
+			let message = error instanceof Error ? error.message : String(error);
+			if (mcpErrorMessage) {
+				message = `${message} (MCP tool fallback failed: ${mcpErrorMessage})`;
+			}
+			console.error(`Error: ${message}`);
+			process.exit(1);
+		}
+	})
+	.addHelpText('after', () => '\nExample:\n  ' + "./calendly get-event-type --event-type-uri https://api.calendly.com/event_types/ET_123");
 
 program
 	.command("get-event-type-availability")

--- a/src/get-event-type.test.ts
+++ b/src/get-event-type.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from 'bun:test';
+import {
+	extractEventTypeUuid,
+	normalizeGetEventTypeQuery,
+	shapeGetEventTypeResult,
+} from './get-event-type';
+
+describe('normalizeGetEventTypeQuery', () => {
+	test('normalizes required args from flags', () => {
+		const query = normalizeGetEventTypeQuery({
+			eventTypeUri: ' https://api.calendly.com/event_types/AAA ',
+		});
+
+		expect(query).toEqual({
+			event_type_uri: 'https://api.calendly.com/event_types/AAA',
+			event_type: 'https://api.calendly.com/event_types/AAA',
+		});
+	});
+
+	test('uses raw fallback and flag override', () => {
+		const query = normalizeGetEventTypeQuery(
+			{
+				eventTypeUri: 'https://api.calendly.com/event_types/FLAG',
+			},
+			{
+				event_type_uri: 'https://api.calendly.com/event_types/RAW',
+			}
+		);
+
+		expect(query).toEqual({
+			event_type_uri: 'https://api.calendly.com/event_types/FLAG',
+			event_type: 'https://api.calendly.com/event_types/FLAG',
+		});
+	});
+
+	test('accepts MCP-style event_type key in raw input', () => {
+		const query = normalizeGetEventTypeQuery(
+			{},
+			{
+				event_type: 'https://api.calendly.com/event_types/RAW_MCP',
+			}
+		);
+
+		expect(query).toEqual({
+			event_type_uri: 'https://api.calendly.com/event_types/RAW_MCP',
+			event_type: 'https://api.calendly.com/event_types/RAW_MCP',
+		});
+	});
+
+	test('rejects missing required args', () => {
+		expect(() => normalizeGetEventTypeQuery({})).toThrow('event_type_uri is required');
+	});
+});
+
+describe('extractEventTypeUuid', () => {
+	test('extracts UUID from event type URI', () => {
+		expect(extractEventTypeUuid('https://api.calendly.com/event_types/ABC123')).toBe('ABC123');
+		expect(extractEventTypeUuid('https://api.calendly.com/event_types/ABC123/')).toBe('ABC123');
+		expect(extractEventTypeUuid('https://api.calendly.com/event_types/ABC123?foo=bar')).toBe('ABC123');
+	});
+
+	test('rejects invalid event type URI format', () => {
+		expect(() => extractEventTypeUuid('https://api.calendly.com/users/U1')).toThrow(
+			'event_type_uri must include an event type UUID'
+		);
+	});
+});
+
+describe('shapeGetEventTypeResult', () => {
+	test('returns normalized query/meta and resource from API-style payload', () => {
+		const shaped = shapeGetEventTypeResult(
+			{
+				resource: {
+					uri: 'https://api.calendly.com/event_types/E1',
+					name: 'Demo',
+					slug: 'demo',
+					duration: 30,
+				},
+			},
+			{
+				event_type_uri: 'https://api.calendly.com/event_types/E1',
+				event_type: 'https://api.calendly.com/event_types/E1',
+			}
+		);
+
+		expect(shaped).toEqual({
+			query: {
+				event_type_uri: 'https://api.calendly.com/event_types/E1',
+			},
+			meta: {
+				found: true,
+			},
+			resource: {
+				uri: 'https://api.calendly.com/event_types/E1',
+				name: 'Demo',
+				slug: 'demo',
+				duration: 30,
+			},
+		});
+	});
+
+	test('supports direct resource payloads and marks missing resources', () => {
+		const direct = shapeGetEventTypeResult(
+			{
+				uri: 'https://api.calendly.com/event_types/E2',
+				name: 'Kickoff',
+			},
+			{
+				event_type_uri: 'https://api.calendly.com/event_types/E2',
+				event_type: 'https://api.calendly.com/event_types/E2',
+			}
+		);
+		expect((direct.meta as Record<string, unknown>).found).toBe(true);
+		expect((direct.resource as Record<string, unknown>).uri).toBe('https://api.calendly.com/event_types/E2');
+
+		const missing = shapeGetEventTypeResult(
+			{},
+			{
+				event_type_uri: 'https://api.calendly.com/event_types/E3',
+				event_type: 'https://api.calendly.com/event_types/E3',
+			}
+		);
+		expect(missing).toEqual({
+			query: {
+				event_type_uri: 'https://api.calendly.com/event_types/E3',
+			},
+			meta: {
+				found: false,
+			},
+			resource: null,
+		});
+	});
+});

--- a/src/get-event-type.ts
+++ b/src/get-event-type.ts
@@ -1,0 +1,80 @@
+export type GetEventTypeCmdOptions = {
+	raw?: string;
+	eventTypeUri?: string;
+};
+
+export type GetEventTypeQuery = {
+	event_type_uri: string;
+	event_type: string;
+};
+
+const EVENT_TYPE_URI_EXAMPLE = 'https://api.calendly.com/event_types/AAAAAAAAAAAAAAAA';
+
+function normalizeRequiredString(value: unknown, fieldName: string, requiredMessage: string): string {
+	if (value === undefined || value === null) {
+		throw new Error(requiredMessage);
+	}
+	if (typeof value !== 'string') {
+		throw new Error(`${fieldName} must be a non-empty string`);
+	}
+	const trimmed = value.trim();
+	if (!trimmed) {
+		throw new Error(`${fieldName} must be a non-empty string`);
+	}
+	return trimmed;
+}
+
+export function normalizeGetEventTypeQuery(
+	cmdOpts: GetEventTypeCmdOptions,
+	defaults: Record<string, unknown> = {}
+): GetEventTypeQuery {
+	const eventTypeUri = normalizeRequiredString(
+		cmdOpts.eventTypeUri ?? defaults.event_type_uri ?? defaults.event_type,
+		'event_type_uri',
+		'event_type_uri is required (use --event-type-uri or --raw {"event_type_uri":"..."})'
+	);
+	return {
+		event_type_uri: eventTypeUri,
+		event_type: eventTypeUri,
+	};
+}
+
+export function extractEventTypeUuid(eventTypeUri: string): string {
+	const match = eventTypeUri.match(/\/event_types\/([^/?#]+)(?:[/?#]|$)/);
+	if (!match || !match[1]) {
+		throw new Error(`event_type_uri must include an event type UUID (example: ${EVENT_TYPE_URI_EXAMPLE})`);
+	}
+	return match[1];
+}
+
+function toRecord(value: unknown): Record<string, unknown> {
+	return value && typeof value === 'object' ? { ...(value as Record<string, unknown>) } : {};
+}
+
+function extractResource(result: Record<string, unknown>): Record<string, unknown> | null {
+	if (result.resource && typeof result.resource === 'object') {
+		return toRecord(result.resource);
+	}
+	if (typeof result.uri === 'string' || typeof result.slug === 'string' || typeof result.name === 'string') {
+		return toRecord(result);
+	}
+	return null;
+}
+
+export function shapeGetEventTypeResult(
+	result: unknown,
+	query: GetEventTypeQuery
+): Record<string, unknown> {
+	const response = toRecord(result);
+	const resource = extractResource(response);
+	const shaped: Record<string, unknown> = {
+		query: {
+			event_type_uri: query.event_type_uri,
+		},
+		meta: {
+			found: Boolean(resource),
+		},
+		resource,
+	};
+	return shaped;
+}


### PR DESCRIPTION
## What
- add new `get-event-type` CLI command with required `--event-type-uri`
- implement MCP-first execution with REST fallback (`GET /event_types/{uuid}`) for parity with `get-event-type-availability`
- add strict input validation + response shaping in new module (`src/get-event-type.ts`)
- wire command metadata/help/signatures/schema in `calendly`
- add unit tests for normalization, UUID extraction, and result shaping (`src/get-event-type.test.ts`)
- update docs in `README.md` and `SKILL.md`

## Why
- completes issue #23 by allowing single event-type detail lookup instead of only list/availability workflows
- keeps behavior consistent with the established resilient command pattern (MCP first, REST fallback)

## Tests
- `bun test`
- `./calendly --help`
- `./calendly get-event-type --help`
- `./calendly --help | rg -n "get-event-type|get-event-type-availability|list-event-types"`
- `codex review --uncommitted` (no P0-P2 findings)

## AI Assistance
- Used: yes (OpenAI Codex CLI)
- Testing level: unit tests + CLI help checks
- Prompt/session log link: local Codex CLI session (not publicly hosted)
- I understand this code.

Closes #23
