### PR TITLE
feat(cli): add schedule-event command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Moltbot skill for Calendly integration. List events, check availability, manage 
 ## Features
 
 - **User Info**: Get authenticated user details
-- **Event Management**: List, view, and cancel scheduled events
+- **Event Management**: List, view, schedule, and cancel events
 - **Invitee Management**: View event invitees
 - **Organization**: List organization memberships
 
-> **Note:** This CLI now includes `list-event-types`, `get-event-type`, and `get-event-type-availability` with strict argument validation and MCP-first + REST fallback support. `schedule-event` still depends on calendly-mcp-server v2.0.0 being published to npm.
+> **Note:** This CLI includes `schedule-event` with strict validation and MCP-first execution. If the MCP tool is unavailable, it safely falls back to Calendly REST (`POST /invitees`).
 
 ## Installation
 
@@ -143,6 +143,40 @@ Validation rules:
 Validation rules:
 - `--event-type-uri` is required (also enforced for `--raw` JSON).
 
+### Schedule Event
+
+```bash
+./calendly schedule-event \
+  --event-type "https://api.calendly.com/event_types/<EVENT_TYPE_UUID>" \
+  --start-time "2099-03-01T15:00:00Z" \
+  --invitee-email "invitee@example.com" \
+  --invitee-name "Invitee Name" \
+  --invitee-timezone "America/New_York" \
+  --questions '{"Company":"Acme"}' \
+  -o json
+```
+
+Validation rules:
+- required args match upstream `calendly-mcp-server` scheduling branch signature: `event_type`, `start_time`, `invitee_email`, `invitee_timezone`
+- `--start-time` must be ISO-8601 and in the future
+- `--event-type` must be a Calendly event type URI
+- `--invitee-email` and optional `--event-guest` values must be valid emails
+- `--invitee-timezone` must be a valid IANA timezone
+- use either `--invitee-name` or `--invitee-first-name`/`--invitee-last-name`, not both
+- `--questions-and-answers` / `--questions` must be valid JSON object/array
+
+Optional scheduling fields:
+- `--invitee-phone` (E.164)
+- `--location-kind` and `--location-details`
+- repeated `--event-guest` (up to 10)
+- `--utm-source`, `--utm-campaign`, `--utm-medium`
+
+Response includes normalized booking details when available:
+- `resource.event_uuid`
+- `resource.meeting_link`
+- `resource.add_to_calendar_links`
+- `resource.status`
+
 ### Get Event Details
 
 ```bash
@@ -200,6 +234,7 @@ Signing secret handling guidance:
 - `list-event-types` - List available event types for scheduling (requires at least one of `--user-uri` or `--organization-uri`)
 - `get-event-type` - Get details for a specific event type (requires `--event-type-uri`)
 - `get-event-type-availability` - Get available time slots for a specific event type
+- `schedule-event` - Schedule a meeting for an invitee on an organizer's event type
 - `cancel-event` - Cancel an event
 - `list-event-invitees` - List invitees for a specific event
 - `search-invitees` - Search events by invitee email across paginated results
@@ -236,22 +271,11 @@ Then use in conversations:
 - "Cancel my 2pm meeting"
 - "Who's attending my next call?"
 
-## Upgrade to v2.0
+## Scheduling Notes
 
-Once calendly-mcp-server v2.0.0 is published to npm (adds the remaining Scheduling API surface), regenerate the CLI:
-
-```bash
-# Update to v2.0+
-MCPORTER_CONFIG=./mcporter.json npx mcporter@latest generate-cli --server calendly --output calendly
-
-# Verify new commands appear
-./calendly --help | grep -E "schedule-event"
-```
-
-The remaining v2.0 Scheduling API commands will add:
-- `schedule-event` - Schedule meetings programmatically
-
-**Requires:** Paid Calendly plan (Standard or higher)
+- `schedule-event` requires a paid Calendly plan (Standard or higher). Free plans receive `403`.
+- Safe error messages are returned for common failures: invalid event type, unavailable slot, custom question validation, and plan restrictions.
+- For the most reliable bookings, fetch slots first via `get-event-type-availability` and then schedule exactly one returned `start_time`.
 
 ## Development
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -7,7 +7,7 @@ description: Calendly scheduling integration. List events, check availability, m
 
 Interact with Calendly scheduling via MCP-generated CLI.
 
-> **Note:** This CLI includes `list-event-types`, `get-event-type`, and `get-event-type-availability` with strict input validation and MCP-first + REST fallback. `schedule-event` still requires calendly-mcp-server v2.0.0 on npm.
+> **Note:** This CLI includes `schedule-event` with strict input validation and MCP-first execution. If MCP scheduling is unavailable, it falls back to Calendly REST (`POST /invitees`).
 
 ## Quick Start
 
@@ -40,6 +40,7 @@ calendly cancel-event --event-uuid <UUID> --reason "Rescheduling needed"
 - `list-event-types` - List schedulable event types (requires `--user-uri` or `--organization-uri`; optional `--count`)
 - `get-event-type` - Get event type details (requires `--event-type-uri`)
 - `get-event-type-availability` - Get available slots for an event type (`--event-type-uri`, `--start-time`, `--end-time`; optional `--timezone`)
+- `schedule-event` - Schedule a meeting by booking an invitee into an event type
 - `cancel-event` - Cancel an event (requires --event-uuid, optional --reason)
 
 ### Invitees
@@ -121,6 +122,16 @@ calendly get-event-type-availability \
   --timezone "America/New_York" \
   -o json
 
+# Schedule an event (requires paid plan)
+calendly schedule-event \
+  --event-type "https://api.calendly.com/event_types/<EVENT_TYPE_UUID>" \
+  --start-time "2099-03-01T15:00:00Z" \
+  --invitee-email "invitee@example.com" \
+  --invitee-name "Invitee Name" \
+  --invitee-timezone "America/New_York" \
+  --questions '{"Company":"Acme"}' \
+  -o json
+
 # List event types
 calendly list-event-types \
   --organization-uri "https://api.calendly.com/organizations/<ORG_UUID>" \
@@ -166,30 +177,22 @@ Webhook signing secret guidance:
 - Verify Calendly webhook signatures in your receiver with the same secret used at subscription creation.
 - If using `--scope user`, include `--user-uri "https://api.calendly.com/users/<USER_UUID>"`.
 
-## Remaining Scheduling API (v2.0)
+## Scheduling Requirements
 
-Once calendly-mcp-server v2.0.0 is published, these additional commands will be available:
+`schedule-event` uses the upstream `calendly-mcp-server` scheduling signature:
+- Required: `event_type`, `start_time`, `invitee_email`, `invitee_timezone`
+- Optional: `invitee_name`, `invitee_first_name`, `invitee_last_name`, `invitee_phone`, `location_kind`, `location_details`, `event_guests`, `questions_and_answers`, `utm_source`, `utm_campaign`, `utm_medium`
 
-### Scheduling Workflow
-```bash
-# 1. Schedule a meeting (requires paid Calendly plan)
-calendly schedule-event \
-  --event-type "<EVENT_TYPE_URI>" \
-  --start-time "2026-01-25T19:00:00Z" \
-  --invitee-email "client@company.com" \
-  --invitee-name "John Smith" \
-  --invitee-timezone "America/New_York"
-```
+Validation behavior:
+- `start_time` must be ISO-8601 and in the future
+- `event_type` must be a Calendly event type URI
+- invitee and guest emails must be valid
+- timezone must be valid IANA timezone
+- custom questions must be valid JSON object/array
 
-**Scheduling API Requirements:**
-- calendly-mcp-server v2.0.0+ (unreleased as of 2026-02-23)
-- Paid Calendly plan (Standard or higher)
-
-To upgrade when v2.0 is published:
-```bash
-cd ~/clawd/skills/calendly
-MCPORTER_CONFIG=./mcporter.json npx mcporter@latest generate-cli --server calendly --output calendly
-```
+Plan and availability notes:
+- Paid Calendly plan (Standard or higher) is required; free plans return `403`.
+- To reduce booking conflicts, call `get-event-type-availability` first and pass one returned slot `start_time`.
 
 ## Important: Time Filtering
 
@@ -235,5 +238,5 @@ calendly list-events --user-uri "<URI>" --min-start-time "$(date -u +%Y-%m-%dT%H
 ---
 
 **Generated:** 2026-01-20  
-**Updated:** 2026-02-23 (Added get-event-type command plus validation + MCP-first REST fallback)
+**Updated:** 2026-02-23 (Added schedule-event command with validation + MCP-first REST fallback)
 **Source:** meAmitPatil/calendly-mcp-server via mcporter

--- a/calendly
+++ b/calendly
@@ -12,6 +12,13 @@ import { fetchBatchEventInvitees, normalizeBatchEventInviteesQuery } from './src
 import { normalizeEventTypeAvailabilityQuery, shapeEventTypeAvailabilityResult } from './src/event-type-availability';
 import { extractEventTypeUuid, normalizeGetEventTypeQuery, shapeGetEventTypeResult } from './src/get-event-type';
 import {
+	normalizeScheduleEventQuery,
+	shapeScheduleEventResult,
+	toSafeScheduleEventError,
+	toScheduleEventMcpArgs,
+	toScheduleEventRestBody,
+} from './src/schedule-event';
+import {
 	normalizeListEventTypesQuery,
 	shapeListEventTypesResult,
 	toListEventTypesMcpArgs,
@@ -180,6 +187,102 @@ const embeddedSchemas = {
       "end_time"
     ]
   },
+  "schedule_event": {
+    "type": "object",
+    "properties": {
+      "event_type": {
+        "type": "string",
+        "description": "URI of the event type to schedule"
+      },
+      "start_time": {
+        "type": "string",
+        "description": "Start time for the event (ISO 8601 UTC format, e.g., 2025-10-02T18:30:00Z)"
+      },
+      "invitee_name": {
+        "type": "string",
+        "description": "Full name of the invitee (alternative to first_name/last_name)"
+      },
+      "invitee_first_name": {
+        "type": "string",
+        "description": "First name of the invitee"
+      },
+      "invitee_last_name": {
+        "type": "string",
+        "description": "Last name of the invitee"
+      },
+      "invitee_email": {
+        "type": "string",
+        "description": "Email address of the invitee"
+      },
+      "invitee_timezone": {
+        "type": "string",
+        "description": "Timezone of the invitee (e.g., America/New_York)"
+      },
+      "invitee_phone": {
+        "type": "string",
+        "description": "Phone number for SMS reminders (E.164 format, e.g., +14155551234)"
+      },
+      "location_kind": {
+        "type": "string",
+        "description": "Type of meeting location (e.g., zoom_conference, google_conference, physical, ask_invitee)"
+      },
+      "location_details": {
+        "type": "string",
+        "description": "Location details (required for physical meetings or custom locations)"
+      },
+      "event_guests": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Array of additional email addresses to include (max 10)"
+      },
+      "questions_and_answers": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "question": {
+              "type": "string",
+              "description": "The question text (must match exactly)"
+            },
+            "answer": {
+              "type": "string",
+              "description": "The answer to the question"
+            },
+            "position": {
+              "type": "number",
+              "description": "Position of the question"
+            }
+          },
+          "required": [
+            "question",
+            "answer",
+            "position"
+          ]
+        },
+        "description": "Array of question and answer pairs for booking form"
+      },
+      "utm_source": {
+        "type": "string",
+        "description": "UTM tracking parameter for source"
+      },
+      "utm_campaign": {
+        "type": "string",
+        "description": "UTM tracking parameter for campaign"
+      },
+      "utm_medium": {
+        "type": "string",
+        "description": "UTM tracking parameter for medium"
+      }
+    },
+    "required": [
+      "event_type",
+      "start_time",
+      "invitee_email",
+      "invitee_timezone"
+    ]
+  },
   "get_event_type": {
     "type": "object",
     "properties": {
@@ -342,6 +445,12 @@ const generatorTools = [
     "flags": "--event-type-uri <event-type-uri> --start-time <start-time:iso-8601> --end-time <end-time:iso-8601> [--timezone <timezone>] [--raw <json>]"
   },
   {
+    "name": "schedule-event",
+    "description": "Schedule a meeting by creating an invitee for a specific event type and time",
+    "usage": "schedule-event --event-type <event-type-uri> --start-time <start-time:iso-8601> --invitee-email <invitee-email> --invitee-timezone <invitee-timezone> [--invitee-name <invitee-name>] [--invitee-first-name <invitee-first-name>] [--invitee-last-name <invitee-last-name>] [--invitee-phone <invitee-phone:e164>] [--location-kind <location-kind>] [--location-details <location-details>] [--event-guest <event-guest>] [--questions-and-answers <questions-and-answers:json>] [--questions <questions:json>] [--utm-source <utm-source>] [--utm-campaign <utm-campaign>] [--utm-medium <utm-medium>] [--raw <json>]",
+    "flags": "--event-type <event-type-uri> --start-time <start-time:iso-8601> --invitee-email <invitee-email> --invitee-timezone <invitee-timezone> [--invitee-name <invitee-name>] [--invitee-first-name <invitee-first-name>] [--invitee-last-name <invitee-last-name>] [--invitee-phone <invitee-phone:e164>] [--location-kind <location-kind>] [--location-details <location-details>] [--event-guest <event-guest>] [--questions-and-answers <questions-and-answers:json>] [--questions <questions:json>] [--utm-source <utm-source>] [--utm-campaign <utm-campaign>] [--utm-medium <utm-medium>] [--raw <json>]"
+  },
+  {
     "name": "get-event",
     "description": "Get details of a specific event",
     "usage": "get-event --event-uuid <event-uuid> [--raw <json>]",
@@ -458,6 +567,7 @@ const commandSignatures: Record<string, string> = {
   "list-event-types": "function list_event_types(user?: string, organization?: string, count?: number);",
   "get-event-type": "function get_event_type(event_type: string);",
   "get-event-type-availability": "function get_event_type_availability(event_type: string, start_time: string, end_time: string, timezone?: string);",
+  "schedule-event": "function schedule_event(event_type: string, start_time: string, invitee_email: string, invitee_timezone: string, invitee_name?: string, invitee_first_name?: string, invitee_last_name?: string, invitee_phone?: string, location_kind?: string, location_details?: string, event_guests?: string[], questions_and_answers?: {question: string, answer: string, position: number}[], utm_source?: string, utm_campaign?: string, utm_medium?: string);",
   "get-event": "function get_event(event_uuid: string);",
   "batch-event-invitees": "function batch_event_invitees(event_uri: string[], status?: \"active\" | \"canceled\", email?: string, count?: number, max_invitee_fetches?: number);",
   "list-event-invitees": "function list_event_invitees(event_uuid: string, status?: \"active\" | \"canceled\", email?: string, count?: number);",
@@ -602,6 +712,24 @@ async function fetchEventTypeAvailabilityResult(query: Record<string, unknown>, 
 		}
 	);
 	return shapeEventTypeAvailabilityResult(response.data, query as any);
+}
+
+async function fetchScheduleEventResult(query: Record<string, unknown>, timeout: number): Promise<any> {
+	const apiKey = process.env.CALENDLY_API_KEY;
+	if (!apiKey) throw new Error('CALENDLY_API_KEY environment variable is required');
+
+	const response = await axios.post(
+		'https://api.calendly.com/invitees',
+		toScheduleEventRestBody(query as any),
+		{
+			headers: {
+				'Authorization': `Bearer ${apiKey}`,
+				'Content-Type': 'application/json',
+			},
+			timeout,
+		}
+	);
+	return shapeScheduleEventResult(response.data, query as any);
 }
 
 async function fetchScheduledEventsWithInvitees(query: Record<string, unknown>, timeout: number): Promise<any> {
@@ -1350,6 +1478,74 @@ program
 		}
 	})
 	.addHelpText('after', () => '\nExample:\n  ' + "./calendly get-event-type-availability --event-type-uri https://api.calendly.com/event_types/ET_123 --start-time 2026-03-01T00:00:00Z --end-time 2026-03-02T00:00:00Z --timezone America/New_York");
+
+program
+	.command("schedule-event")
+	.summary("schedule-event --event-type <event-type-uri> --start-time <start-time:iso-8601> --invitee-email <invitee-email> --invitee-timezone <invitee-timezone> [--invitee-name <invitee-name>] [--invitee-first-name <invitee-first-name>] [--invitee-last-name <invitee-last-name>] [--invitee-phone <invitee-phone:e164>] [--location-kind <location-kind>] [--location-details <location-details>] [--event-guest <event-guest>] [--questions-and-answers <questions-and-answers:json>] [--questions <questions:json>] [--utm-source <utm-source>] [--utm-campaign <utm-campaign>] [--utm-medium <utm-medium>] [--raw <json>]")
+	.description("Schedule a meeting by creating an invitee for a specific event type and time")
+	.usage("--event-type <event-type-uri> --start-time <start-time:iso-8601> --invitee-email <invitee-email> --invitee-timezone <invitee-timezone> [--invitee-name <invitee-name>] [--invitee-first-name <invitee-first-name>] [--invitee-last-name <invitee-last-name>] [--invitee-phone <invitee-phone:e164>] [--location-kind <location-kind>] [--location-details <location-details>] [--event-guest <event-guest>] [--questions-and-answers <questions-and-answers:json>] [--questions <questions:json>] [--utm-source <utm-source>] [--utm-campaign <utm-campaign>] [--utm-medium <utm-medium>] [--raw <json>]")
+	.option('--raw <json>', 'Provide raw JSON arguments to the tool, bypassing flag parsing.')
+	.option("--event-type <event-type-uri>", "Event type URI to schedule")
+	.option("--start-time <start-time:iso-8601>", "Start time for the event (ISO 8601 format; must be in the future)")
+	.option("--invitee-email <invitee-email>", "Email address of the invitee")
+	.option("--invitee-timezone <invitee-timezone>", "Invitee timezone (IANA, example: America/New_York)")
+	.option("--invitee-name <invitee-name>", "Invitee full name (alternative to first/last name)")
+	.option("--invitee-first-name <invitee-first-name>", "Invitee first name")
+	.option("--invitee-last-name <invitee-last-name>", "Invitee last name")
+	.option("--invitee-phone <invitee-phone:e164>", "Invitee phone for SMS reminders in E.164 format")
+	.option("--location-kind <location-kind>", "Meeting location kind (zoom_conference, google_conference, physical, ask_invitee, etc.)")
+	.option("--location-details <location-details>", "Optional location details; requires --location-kind")
+	.option("--event-guest <event-guest>", "Additional guest email; repeat up to 10 entries", collectRepeatedString, [] as string[])
+	.option("--questions-and-answers <questions-and-answers:json>", "JSON array/object for booking questions (e.g. '[{\"question\":\"Company\",\"answer\":\"Acme\",\"position\":1}]')")
+	.option("--questions <questions:json>", "Compatibility alias for --questions-and-answers (JSON object or array)")
+	.option("--utm-source <utm-source>", "Optional UTM source")
+	.option("--utm-campaign <utm-campaign>", "Optional UTM campaign")
+	.option("--utm-medium <utm-medium>", "Optional UTM medium")
+	.alias("schedule_event")
+	.action(async (cmdOpts) => {
+		const globalOptions = program.opts();
+		const timeout = globalOptions.timeout || 30000;
+		const rawArgs = cmdOpts.raw ? JSON.parse(cmdOpts.raw) : ({} as Record<string, unknown>);
+		const query = normalizeScheduleEventQuery(cmdOpts, rawArgs);
+		let mcpErrorMessage: string | undefined;
+		try {
+			const runtime = await ensureRuntime();
+			const serverName = embeddedName;
+			const proxy = createServerProxy(runtime, serverName, {
+				initialSchemas: embeddedSchemas,
+			});
+			try {
+				const call = (proxy.scheduleEvent as any)(toScheduleEventMcpArgs(query));
+				const mcpResult = await invokeWithTimeout(call, timeout);
+				const mcpRaw = createCallResult(mcpResult).raw as Record<string, unknown> | undefined;
+				if (mcpRaw && (mcpRaw.resource || mcpRaw.uri || mcpRaw.event)) {
+					printResult(shapeScheduleEventResult(mcpRaw, query), globalOptions.output ?? 'text');
+					return;
+				}
+				printResult(mcpResult, globalOptions.output ?? 'text');
+				return;
+			} catch (error) {
+				mcpErrorMessage = error instanceof Error ? error.message : String(error);
+			} finally {
+				await runtime.close(serverName).catch(() => {});
+			}
+		} catch (error) {
+			mcpErrorMessage = error instanceof Error ? error.message : String(error);
+		}
+
+		try {
+			const restResult = await fetchScheduleEventResult(query, timeout);
+			printResult(restResult, globalOptions.output ?? 'text');
+		} catch (error) {
+			let message = toSafeScheduleEventError(error);
+			if (mcpErrorMessage) {
+				message = `${message} (MCP tool fallback failed: ${mcpErrorMessage})`;
+			}
+			console.error(`Error: ${message}`);
+			process.exit(1);
+		}
+	})
+	.addHelpText('after', () => '\nExample:\n  ' + "./calendly schedule-event --event-type https://api.calendly.com/event_types/ET_123 --start-time 2099-03-01T15:00:00Z --invitee-email invitee@example.com --invitee-name \"Jane Doe\" --invitee-timezone America/New_York --questions '{\"Company\":\"Acme\"}'");
 
 program
 	.command("get-event")

--- a/src/schedule-event.test.ts
+++ b/src/schedule-event.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, test } from 'bun:test';
+import {
+	normalizeScheduleEventQuery,
+	shapeScheduleEventResult,
+	toSafeScheduleEventError,
+	toScheduleEventRestBody,
+} from './schedule-event';
+
+const FUTURE_TIME = '2099-03-01T15:00:00Z';
+
+describe('normalizeScheduleEventQuery', () => {
+	test('normalizes required fields and optional invitee name', () => {
+		const query = normalizeScheduleEventQuery({
+			eventType: ' https://api.calendly.com/event_types/ET_123 ',
+			startTime: FUTURE_TIME,
+			inviteeEmail: ' Person@Example.com ',
+			inviteeTimezone: 'America/New_York',
+			inviteeName: 'John Smith',
+		});
+
+		expect(query).toEqual({
+			event_type: 'https://api.calendly.com/event_types/ET_123',
+			start_time: FUTURE_TIME,
+			invitee_email: 'person@example.com',
+			invitee_timezone: 'America/New_York',
+			invitee_name: 'John Smith',
+		});
+	});
+
+	test('supports nested raw invitee defaults', () => {
+		const query = normalizeScheduleEventQuery(
+			{
+				eventType: 'https://api.calendly.com/event_types/ET_123',
+				startTime: FUTURE_TIME,
+			},
+			{
+				invitee: {
+					email: 'invitee@example.com',
+					timezone: 'America/Los_Angeles',
+					first_name: 'Ada',
+					last_name: 'Lovelace',
+				},
+			}
+		);
+
+		expect(query.invitee_email).toBe('invitee@example.com');
+		expect(query.invitee_timezone).toBe('America/Los_Angeles');
+		expect(query.invitee_first_name).toBe('Ada');
+		expect(query.invitee_last_name).toBe('Lovelace');
+	});
+
+	test('parses questions from JSON object map', () => {
+		const query = normalizeScheduleEventQuery({
+			eventType: 'https://api.calendly.com/event_types/ET_123',
+			startTime: FUTURE_TIME,
+			inviteeEmail: 'invitee@example.com',
+			inviteeTimezone: 'America/New_York',
+			questions: '{"Company size":"50-100","Use case":"Partnerships"}',
+		});
+
+		expect(query.questions_and_answers).toEqual([
+			{ question: 'Company size', answer: '50-100', position: 1 },
+			{ question: 'Use case', answer: 'Partnerships', position: 2 },
+		]);
+	});
+
+	test('validates event guests and dedupes stable order', () => {
+		const query = normalizeScheduleEventQuery({
+			eventType: 'https://api.calendly.com/event_types/ET_123',
+			startTime: FUTURE_TIME,
+			inviteeEmail: 'invitee@example.com',
+			inviteeTimezone: 'America/New_York',
+			eventGuest: ['guest2@example.com', 'guest1@example.com', 'guest2@example.com'],
+		});
+
+		expect(query.event_guests).toEqual(['guest2@example.com', 'guest1@example.com']);
+	});
+
+	test('uses raw event_guests when repeated --event-guest flags are not provided', () => {
+		const query = normalizeScheduleEventQuery(
+			{
+				eventType: 'https://api.calendly.com/event_types/ET_123',
+				startTime: FUTURE_TIME,
+				inviteeEmail: 'invitee@example.com',
+				inviteeTimezone: 'America/New_York',
+			},
+			{
+				event_guests: ['raw1@example.com', 'raw2@example.com'],
+			}
+		);
+
+		expect(query.event_guests).toEqual(['raw1@example.com', 'raw2@example.com']);
+	});
+
+	test('rejects missing required args', () => {
+		expect(() => normalizeScheduleEventQuery({})).toThrow('event_type is required');
+		expect(() =>
+			normalizeScheduleEventQuery({
+				eventType: 'https://api.calendly.com/event_types/ET_123',
+				startTime: FUTURE_TIME,
+			})
+		).toThrow('invitee_email is required');
+	});
+
+	test('rejects invalid format and conflicting name args', () => {
+		expect(() =>
+			normalizeScheduleEventQuery({
+				eventType: 'not-a-uri',
+				startTime: FUTURE_TIME,
+				inviteeEmail: 'invitee@example.com',
+				inviteeTimezone: 'America/New_York',
+			})
+		).toThrow('event_type must be a Calendly event type URI');
+
+		expect(() =>
+			normalizeScheduleEventQuery({
+				eventType: 'https://api.calendly.com/event_types/ET_123',
+				startTime: FUTURE_TIME,
+				inviteeEmail: 'invitee@example.com',
+				inviteeTimezone: 'America/New_York',
+				inviteeName: 'John Smith',
+				inviteeFirstName: 'John',
+			})
+		).toThrow('provide either invitee_name or invitee_first_name/invitee_last_name');
+	});
+
+	test('rejects invalid timezone, past start_time, and location details without kind', () => {
+		expect(() =>
+			normalizeScheduleEventQuery({
+				eventType: 'https://api.calendly.com/event_types/ET_123',
+				startTime: FUTURE_TIME,
+				inviteeEmail: 'invitee@example.com',
+				inviteeTimezone: 'Mars/Olympus',
+			})
+		).toThrow('invitee_timezone must be a valid IANA timezone');
+
+		expect(() =>
+			normalizeScheduleEventQuery({
+				eventType: 'https://api.calendly.com/event_types/ET_123',
+				startTime: '2020-01-01T00:00:00Z',
+				inviteeEmail: 'invitee@example.com',
+				inviteeTimezone: 'America/New_York',
+			})
+		).toThrow('start_time must be in the future');
+
+		expect(() =>
+			normalizeScheduleEventQuery({
+				eventType: 'https://api.calendly.com/event_types/ET_123',
+				startTime: FUTURE_TIME,
+				inviteeEmail: 'invitee@example.com',
+				inviteeTimezone: 'America/New_York',
+				locationDetails: 'Conference Room A',
+			})
+		).toThrow('location_kind is required when location_details is provided');
+	});
+});
+
+describe('toScheduleEventRestBody', () => {
+	test('maps flattened query into REST invitees payload', () => {
+		const payload = toScheduleEventRestBody({
+			event_type: 'https://api.calendly.com/event_types/ET_123',
+			start_time: FUTURE_TIME,
+			invitee_email: 'invitee@example.com',
+			invitee_timezone: 'America/New_York',
+			invitee_name: 'Invitee Name',
+			location_kind: 'zoom_conference',
+			event_guests: ['guest@example.com'],
+			utm_source: 'newsletter',
+		});
+
+		expect(payload).toEqual({
+			event_type: 'https://api.calendly.com/event_types/ET_123',
+			start_time: FUTURE_TIME,
+			invitee: {
+				email: 'invitee@example.com',
+				timezone: 'America/New_York',
+				name: 'Invitee Name',
+			},
+			location: {
+				kind: 'zoom_conference',
+			},
+			event_guests: ['guest@example.com'],
+			tracking: {
+				utm_campaign: null,
+				utm_source: 'newsletter',
+				utm_medium: null,
+				utm_content: null,
+				utm_term: null,
+				salesforce_uuid: null,
+			},
+		});
+	});
+});
+
+describe('shapeScheduleEventResult', () => {
+	test('shapes invitee response with event UUID, links, and meta', () => {
+		const shaped = shapeScheduleEventResult(
+			{
+				resource: {
+					uri: 'https://api.calendly.com/invitees/INV_123',
+					event: 'https://api.calendly.com/scheduled_events/EVT_456',
+					name: 'Invitee Name',
+					email: 'invitee@example.com',
+					status: 'active',
+					reschedule_url: 'https://calendly.com/resched/INV_123',
+					cancel_url: 'https://calendly.com/cancel/INV_123',
+					location: {
+						join_url: 'https://zoom.us/j/123',
+					},
+					calendar_event: {
+						google: 'https://calendar.google.com/event?eid=abc',
+						outlook: 'https://outlook.office.com/calendar/abc',
+					},
+				},
+			},
+			{
+				event_type: 'https://api.calendly.com/event_types/ET_123',
+				start_time: FUTURE_TIME,
+				invitee_email: 'invitee@example.com',
+				invitee_timezone: 'America/New_York',
+			}
+		);
+
+		expect((shaped.meta as Record<string, unknown>).scheduled).toBe(true);
+		expect((shaped.resource as Record<string, unknown>).event_uuid).toBe('EVT_456');
+		expect((shaped.resource as Record<string, unknown>).invitee_uuid).toBe('INV_123');
+		expect((shaped.resource as Record<string, unknown>).meeting_link).toBe('https://zoom.us/j/123');
+		expect((shaped.resource as Record<string, unknown>).add_to_calendar_links).toEqual({
+			google: 'https://calendar.google.com/event?eid=abc',
+			outlook: 'https://outlook.office.com/calendar/abc',
+		});
+	});
+});
+
+describe('toSafeScheduleEventError', () => {
+	test('maps known API errors to safe messages', () => {
+		expect(
+			toSafeScheduleEventError({
+				response: {
+					status: 403,
+				},
+			})
+		).toContain('paid Calendly plan');
+
+		expect(
+			toSafeScheduleEventError({
+				response: {
+					status: 409,
+				},
+			})
+		).toContain('selected start_time is unavailable');
+
+		expect(
+			toSafeScheduleEventError({
+				response: {
+					status: 422,
+					data: {
+						message: 'Questions are invalid',
+					},
+				},
+			})
+		).toContain('custom questions');
+	});
+});

--- a/src/schedule-event.ts
+++ b/src/schedule-event.ts
@@ -1,0 +1,504 @@
+const ISO_8601_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(?:Z|[+-]\d{2}:\d{2})$/;
+const ISO_8601_EXAMPLE = '2026-01-20T00:00:00Z';
+const EVENT_TYPE_URI_EXAMPLE = 'https://api.calendly.com/event_types/AAAAAAAAAAAAAAAA';
+const TIMEZONE_EXAMPLE = 'America/New_York';
+const EMAIL_EXAMPLE = 'invitee@example.com';
+const E164_PHONE_REGEX = /^\+[1-9]\d{6,14}$/;
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export type ScheduleEventCmdOptions = {
+	raw?: string;
+	eventType?: string;
+	startTime?: string;
+	inviteeName?: string;
+	inviteeFirstName?: string;
+	inviteeLastName?: string;
+	inviteeEmail?: string;
+	inviteeTimezone?: string;
+	inviteePhone?: string;
+	locationKind?: string;
+	locationDetails?: string;
+	eventGuest?: string[];
+	questionsAndAnswers?: string;
+	questions?: string;
+	utmSource?: string;
+	utmCampaign?: string;
+	utmMedium?: string;
+};
+
+export type ScheduleQuestionAndAnswer = {
+	question: string;
+	answer: string;
+	position: number;
+};
+
+export type ScheduleEventQuery = {
+	event_type: string;
+	start_time: string;
+	invitee_email: string;
+	invitee_timezone: string;
+	invitee_name?: string;
+	invitee_first_name?: string;
+	invitee_last_name?: string;
+	invitee_phone?: string;
+	location_kind?: string;
+	location_details?: string;
+	event_guests?: string[];
+	questions_and_answers?: ScheduleQuestionAndAnswer[];
+	utm_source?: string;
+	utm_campaign?: string;
+	utm_medium?: string;
+};
+
+function toRecord(value: unknown): Record<string, unknown> {
+	return value && typeof value === 'object' ? { ...(value as Record<string, unknown>) } : {};
+}
+
+function normalizeRequiredString(value: unknown, fieldName: string, requiredMessage: string): string {
+	if (value === undefined || value === null) {
+		throw new Error(requiredMessage);
+	}
+	if (typeof value !== 'string') {
+		throw new Error(`${fieldName} must be a non-empty string`);
+	}
+	const trimmed = value.trim();
+	if (!trimmed) {
+		throw new Error(`${fieldName} must be a non-empty string`);
+	}
+	return trimmed;
+}
+
+function normalizeOptionalString(value: unknown, fieldName: string): string | undefined {
+	if (value === undefined || value === null) {
+		return undefined;
+	}
+	if (typeof value !== 'string') {
+		throw new Error(`${fieldName} must be a non-empty string`);
+	}
+	const trimmed = value.trim();
+	if (!trimmed) {
+		throw new Error(`${fieldName} must be a non-empty string`);
+	}
+	return trimmed;
+}
+
+function normalizeEventType(value: unknown): string {
+	const eventType = normalizeRequiredString(
+		value,
+		'event_type',
+		'event_type is required (use --event-type or --raw {"event_type":"..."})'
+	);
+	if (!eventType.includes('/event_types/')) {
+		throw new Error(`event_type must be a Calendly event type URI (example: ${EVENT_TYPE_URI_EXAMPLE})`);
+	}
+	return eventType;
+}
+
+function normalizeStartTime(value: unknown): string {
+	const startTime = normalizeRequiredString(
+		value,
+		'start_time',
+		'start_time is required (use --start-time or --raw {"start_time":"..."})'
+	);
+	if (!ISO_8601_TIMESTAMP.test(startTime) || Number.isNaN(Date.parse(startTime))) {
+		throw new Error(`start_time must be a valid ISO-8601 timestamp (example: ${ISO_8601_EXAMPLE})`);
+	}
+	if (Date.parse(startTime) <= Date.now()) {
+		throw new Error('start_time must be in the future');
+	}
+	return startTime;
+}
+
+function normalizeEmail(value: unknown, fieldName: string, requiredMessage: string): string {
+	const email = normalizeRequiredString(value, fieldName, requiredMessage).toLowerCase();
+	if (!EMAIL_REGEX.test(email)) {
+		throw new Error(`${fieldName} must be a valid email address (example: ${EMAIL_EXAMPLE})`);
+	}
+	return email;
+}
+
+function normalizeTimezone(value: unknown): string {
+	const timezone = normalizeRequiredString(
+		value,
+		'invitee_timezone',
+		'invitee_timezone is required (use --invitee-timezone or --raw {"invitee_timezone":"..."})'
+	);
+	try {
+		new Intl.DateTimeFormat('en-US', { timeZone: timezone }).format(new Date());
+	} catch {
+		throw new Error(`invitee_timezone must be a valid IANA timezone (example: ${TIMEZONE_EXAMPLE})`);
+	}
+	return timezone;
+}
+
+function normalizePhone(value: unknown): string | undefined {
+	const phone = normalizeOptionalString(value, 'invitee_phone');
+	if (!phone) {
+		return undefined;
+	}
+	if (!E164_PHONE_REGEX.test(phone)) {
+		throw new Error('invitee_phone must be a valid E.164 phone number (example: +14155551234)');
+	}
+	return phone;
+}
+
+function parseJsonOption(value: unknown, fieldName: string): unknown {
+	if (value === undefined || value === null) {
+		return undefined;
+	}
+	if (typeof value !== 'string') {
+		return value;
+	}
+	const trimmed = value.trim();
+	if (!trimmed) {
+		return undefined;
+	}
+	try {
+		return JSON.parse(trimmed);
+	} catch {
+		throw new Error(`${fieldName} must be valid JSON`);
+	}
+}
+
+function normalizeQuestionAndAnswerEntry(value: unknown, index: number): ScheduleQuestionAndAnswer {
+	const record = toRecord(value);
+	const question = normalizeRequiredString(
+		record.question ?? record.question_id ?? record.id,
+		'questions_and_answers.question',
+		'questions_and_answers entries require question and answer fields'
+	);
+	const answerRaw = record.answer ?? record.value;
+	const answer = normalizeRequiredString(
+		typeof answerRaw === 'string' ? answerRaw : answerRaw !== undefined && answerRaw !== null ? String(answerRaw) : undefined,
+		'questions_and_answers.answer',
+		'questions_and_answers entries require question and answer fields'
+	);
+	const positionRaw = record.position;
+	const position =
+		typeof positionRaw === 'number' && Number.isFinite(positionRaw) && Number.isInteger(positionRaw) && positionRaw > 0
+			? positionRaw
+			: index + 1;
+	return {
+		question,
+		answer,
+		position,
+	};
+}
+
+function normalizeQuestionsAndAnswers(value: unknown): ScheduleQuestionAndAnswer[] | undefined {
+	if (value === undefined || value === null) {
+		return undefined;
+	}
+	if (Array.isArray(value)) {
+		if (value.length === 0) {
+			return undefined;
+		}
+		return value.map((entry, index) => normalizeQuestionAndAnswerEntry(entry, index));
+	}
+	if (value && typeof value === 'object') {
+		const record = value as Record<string, unknown>;
+		if ('question' in record || 'answer' in record || 'question_id' in record || 'id' in record) {
+			return [normalizeQuestionAndAnswerEntry(record, 0)];
+		}
+		const entries = Object.entries(record).map(([question, answer], index) =>
+			normalizeQuestionAndAnswerEntry({ question, answer, position: index + 1 }, index)
+		);
+		return entries.length > 0 ? entries : undefined;
+	}
+	throw new Error('questions_and_answers must be a JSON object or array');
+}
+
+function normalizeEventGuests(value: unknown): string[] | undefined {
+	if (value === undefined || value === null) {
+		return undefined;
+	}
+	const candidates: unknown[] = Array.isArray(value) ? value : [value];
+	const normalized: string[] = [];
+	for (const candidate of candidates) {
+		const email = normalizeEmail(
+			candidate,
+			'event_guests',
+			'event_guests must be email strings (use repeated --event-guest or --raw {"event_guests":["..."]})'
+		);
+		if (!normalized.includes(email)) {
+			normalized.push(email);
+		}
+	}
+	if (normalized.length === 0) {
+		return undefined;
+	}
+	if (normalized.length > 10) {
+		throw new Error('event_guests cannot include more than 10 email addresses');
+	}
+	return normalized;
+}
+
+function trimErrorDetail(value: string): string {
+	return value.replace(/\s+/g, ' ').trim().slice(0, 300);
+}
+
+function extractErrorDetail(data: unknown): string | undefined {
+	const record = toRecord(data);
+	const candidates = [
+		record.message,
+		record.title,
+		record.detail,
+		record.error,
+		toRecord(record.resource)?.message,
+	];
+	for (const candidate of candidates) {
+		if (typeof candidate === 'string' && candidate.trim()) {
+			return trimErrorDetail(candidate);
+		}
+	}
+	const details = Array.isArray(record.details) ? record.details : [];
+	for (const entry of details) {
+		const message = toRecord(entry).message;
+		if (typeof message === 'string' && message.trim()) {
+			return trimErrorDetail(message);
+		}
+	}
+	return undefined;
+}
+
+function parseUuidFromUri(uri: string | undefined, segment: string): string | undefined {
+	if (!uri) {
+		return undefined;
+	}
+	const regex = new RegExp(`/${segment}/([^/?#]+)(?:[/?#]|$)`);
+	const match = uri.match(regex);
+	return match && match[1] ? match[1] : undefined;
+}
+
+function pickString(...values: unknown[]): string | undefined {
+	for (const value of values) {
+		if (typeof value === 'string' && value.trim()) {
+			return value;
+		}
+	}
+	return undefined;
+}
+
+export function normalizeScheduleEventQuery(
+	cmdOpts: ScheduleEventCmdOptions,
+	defaults: Record<string, unknown> = {}
+): ScheduleEventQuery {
+	const rawInvitee = toRecord(defaults.invitee);
+	const rawLocation = toRecord(defaults.location);
+	const rawTracking = toRecord(defaults.tracking);
+
+	const eventType = normalizeEventType(cmdOpts.eventType ?? defaults.event_type);
+	const startTime = normalizeStartTime(cmdOpts.startTime ?? defaults.start_time);
+	const inviteeEmail = normalizeEmail(
+		cmdOpts.inviteeEmail ?? defaults.invitee_email ?? rawInvitee.email,
+		'invitee_email',
+		'invitee_email is required (use --invitee-email or --raw {"invitee_email":"..."})'
+	);
+	const inviteeTimezone = normalizeTimezone(
+		cmdOpts.inviteeTimezone ?? defaults.invitee_timezone ?? rawInvitee.timezone
+	);
+	const inviteeName = normalizeOptionalString(cmdOpts.inviteeName ?? defaults.invitee_name ?? rawInvitee.name, 'invitee_name');
+	const inviteeFirstName = normalizeOptionalString(
+		cmdOpts.inviteeFirstName ?? defaults.invitee_first_name ?? rawInvitee.first_name,
+		'invitee_first_name'
+	);
+	const inviteeLastName = normalizeOptionalString(
+		cmdOpts.inviteeLastName ?? defaults.invitee_last_name ?? rawInvitee.last_name,
+		'invitee_last_name'
+	);
+	if (inviteeName && (inviteeFirstName || inviteeLastName)) {
+		throw new Error('provide either invitee_name or invitee_first_name/invitee_last_name, not both');
+	}
+
+	const inviteePhone = normalizePhone(cmdOpts.inviteePhone ?? defaults.invitee_phone ?? rawInvitee.text_reminder_number);
+	const locationKind = normalizeOptionalString(cmdOpts.locationKind ?? defaults.location_kind ?? rawLocation.kind, 'location_kind');
+	const locationDetails = normalizeOptionalString(
+		cmdOpts.locationDetails ?? defaults.location_details ?? rawLocation.location,
+		'location_details'
+	);
+	if (locationDetails && !locationKind) {
+		throw new Error('location_kind is required when location_details is provided');
+	}
+
+	const eventGuests = normalizeEventGuests(
+		Array.isArray(cmdOpts.eventGuest) && cmdOpts.eventGuest.length > 0 ? cmdOpts.eventGuest : defaults.event_guests
+	);
+	const questionsInput =
+		parseJsonOption(cmdOpts.questionsAndAnswers, 'questions_and_answers') ??
+		parseJsonOption(cmdOpts.questions, 'questions') ??
+		defaults.questions_and_answers ??
+		defaults.questions;
+	const questionsAndAnswers = normalizeQuestionsAndAnswers(questionsInput);
+	const utmSource = normalizeOptionalString(cmdOpts.utmSource ?? defaults.utm_source ?? rawTracking.utm_source, 'utm_source');
+	const utmCampaign = normalizeOptionalString(
+		cmdOpts.utmCampaign ?? defaults.utm_campaign ?? rawTracking.utm_campaign,
+		'utm_campaign'
+	);
+	const utmMedium = normalizeOptionalString(cmdOpts.utmMedium ?? defaults.utm_medium ?? rawTracking.utm_medium, 'utm_medium');
+
+	return {
+		event_type: eventType,
+		start_time: startTime,
+		invitee_email: inviteeEmail,
+		invitee_timezone: inviteeTimezone,
+		...(inviteeName ? { invitee_name: inviteeName } : {}),
+		...(inviteeFirstName ? { invitee_first_name: inviteeFirstName } : {}),
+		...(inviteeLastName ? { invitee_last_name: inviteeLastName } : {}),
+		...(inviteePhone ? { invitee_phone: inviteePhone } : {}),
+		...(locationKind ? { location_kind: locationKind } : {}),
+		...(locationDetails ? { location_details: locationDetails } : {}),
+		...(eventGuests && eventGuests.length > 0 ? { event_guests: eventGuests } : {}),
+		...(questionsAndAnswers && questionsAndAnswers.length > 0 ? { questions_and_answers: questionsAndAnswers } : {}),
+		...(utmSource ? { utm_source: utmSource } : {}),
+		...(utmCampaign ? { utm_campaign: utmCampaign } : {}),
+		...(utmMedium ? { utm_medium: utmMedium } : {}),
+	};
+}
+
+export function toScheduleEventMcpArgs(query: ScheduleEventQuery): Record<string, unknown> {
+	return {
+		...query,
+	};
+}
+
+export function toScheduleEventRestBody(query: ScheduleEventQuery): Record<string, unknown> {
+	const invitee: Record<string, unknown> = {
+		email: query.invitee_email,
+		timezone: query.invitee_timezone,
+	};
+	if (query.invitee_name) {
+		invitee.name = query.invitee_name;
+	} else {
+		if (query.invitee_first_name) invitee.first_name = query.invitee_first_name;
+		if (query.invitee_last_name) invitee.last_name = query.invitee_last_name;
+	}
+	if (query.invitee_phone) {
+		invitee.text_reminder_number = query.invitee_phone;
+	}
+
+	const payload: Record<string, unknown> = {
+		event_type: query.event_type,
+		start_time: query.start_time,
+		invitee,
+	};
+	if (query.location_kind) {
+		payload.location = {
+			kind: query.location_kind,
+			...(query.location_details ? { location: query.location_details } : {}),
+		};
+	}
+	if (query.event_guests && query.event_guests.length > 0) {
+		payload.event_guests = query.event_guests;
+	}
+	if (query.questions_and_answers && query.questions_and_answers.length > 0) {
+		payload.questions_and_answers = query.questions_and_answers;
+	}
+	if (query.utm_source || query.utm_campaign || query.utm_medium) {
+		payload.tracking = {
+			utm_campaign: query.utm_campaign ?? null,
+			utm_source: query.utm_source ?? null,
+			utm_medium: query.utm_medium ?? null,
+			utm_content: null,
+			utm_term: null,
+			salesforce_uuid: null,
+		};
+	}
+	return payload;
+}
+
+export function shapeScheduleEventResult(
+	result: unknown,
+	query: ScheduleEventQuery
+): Record<string, unknown> {
+	const response = toRecord(result);
+	const resource = response.resource && typeof response.resource === 'object'
+		? toRecord(response.resource)
+		: response;
+
+	const eventUri = pickString(resource.event, toRecord(resource.event).uri);
+	const inviteeUri = pickString(resource.uri);
+	const eventUuid = parseUuidFromUri(eventUri, 'scheduled_events');
+	const inviteeUuid = parseUuidFromUri(inviteeUri, 'invitees');
+
+	const location = toRecord(resource.location);
+	const eventLocation = toRecord(toRecord(resource.event).location);
+	const meetingLink = pickString(
+		location.join_url,
+		location.location,
+		eventLocation.join_url,
+		eventLocation.location,
+		resource.reschedule_url
+	);
+
+	const calendarEvent = toRecord(resource.calendar_event);
+	const addToCalendarLinks: Record<string, string> = {};
+	const google = pickString(calendarEvent.google, calendarEvent.google_calendar);
+	const outlook = pickString(calendarEvent.outlook);
+	const ics = pickString(calendarEvent.ics, calendarEvent.ical);
+	if (google) addToCalendarLinks.google = google;
+	if (outlook) addToCalendarLinks.outlook = outlook;
+	if (ics) addToCalendarLinks.ics = ics;
+
+	return {
+		query: {
+			event_type: query.event_type,
+			start_time: query.start_time,
+			invitee_email: query.invitee_email,
+			invitee_timezone: query.invitee_timezone,
+		},
+		meta: {
+			scheduled: Boolean(resource && Object.keys(resource).length > 0),
+			calendar_invite_sent: typeof resource.status === 'string' ? resource.status === 'active' : undefined,
+		},
+		resource: {
+			event_uri: eventUri ?? null,
+			event_uuid: eventUuid ?? null,
+			invitee_uri: inviteeUri ?? null,
+			invitee_uuid: inviteeUuid ?? null,
+			invitee_name: pickString(resource.name, query.invitee_name) ?? null,
+			invitee_email: pickString(resource.email, query.invitee_email) ?? null,
+			status: pickString(resource.status) ?? null,
+			meeting_link: meetingLink ?? null,
+			cancel_url: pickString(resource.cancel_url) ?? null,
+			reschedule_url: pickString(resource.reschedule_url) ?? null,
+			add_to_calendar_links: addToCalendarLinks,
+		},
+	};
+}
+
+export function toSafeScheduleEventError(error: unknown): string {
+	const record = toRecord(error);
+	const response = toRecord(record.response);
+	const status = typeof response.status === 'number' ? response.status : undefined;
+	const detail = extractErrorDetail(response.data ?? record);
+	const detailLower = detail?.toLowerCase();
+
+	if (status === 401) {
+		return 'Authentication failed. Set a valid CALENDLY_API_KEY.';
+	}
+	if (status === 403) {
+		return 'Scheduling API requires a paid Calendly plan (Standard or higher).';
+	}
+	if (status === 404) {
+		return 'event_type was not found or is not accessible. Verify --event-type and your account permissions.';
+	}
+	if (status === 409 || (status === 422 && detailLower?.includes('available'))) {
+		return 'The selected start_time is unavailable. Choose another slot from get-event-type-availability.';
+	}
+	if (status === 422 && detailLower?.includes('question')) {
+		return 'Booking failed validation for custom questions. Verify --questions/--questions-and-answers matches event type requirements.';
+	}
+	if (status === 422) {
+		return 'Booking request was rejected by Calendly. Verify invitee details and selected slot.';
+	}
+	if (status === 429) {
+		return 'Calendly API rate limit reached. Retry shortly.';
+	}
+	if (detail) {
+		return `Unable to schedule event: ${detail}`;
+	}
+	if (error instanceof Error && error.message.trim()) {
+		return error.message;
+	}
+	return 'Unable to schedule event. Verify event type, slot availability, and invitee details.';
+}


### PR DESCRIPTION
## What
- Add `schedule-event` command to `calendly` CLI with MCP-first execution and REST fallback (`POST /invitees`) when MCP scheduling is unavailable.
- Confirm and mirror upstream scheduling signature from `meAmitPatil/calendly-mcp-server` branch `feature/scheduling-api`:
  - Required: `event_type`, `start_time`, `invitee_email`, `invitee_timezone`
  - Optional: `invitee_name`, `invitee_first_name`, `invitee_last_name`, `invitee_phone`, `location_kind`, `location_details`, `event_guests`, `questions_and_answers`, `utm_source`, `utm_campaign`, `utm_medium`
- Add new module `src/schedule-event.ts` for:
  - robust normalization/validation (ISO-8601 + future start time, URI/email/timezone/phone validation, question JSON parsing, guest limits)
  - MCP argument shaping
  - REST payload shaping
  - normalized output shaping (event UUID/link/calendar links/status when available)
  - safe error mapping (plan restriction, invalid event type, unavailable slot, custom question validation, auth/rate-limit)
- Add tests in `src/schedule-event.test.ts` for parsing/validation, payload mapping, output shaping, and safe error mapping.
- Update docs (`README.md`, `SKILL.md`) with new command usage, examples, validation rules, and scheduling notes.
- Update CLI help metadata/signatures/examples to expose `schedule-event` in top-level and per-command help.

## Why
- Implements issue #28 by enabling programmatic booking directly from the CLI.
- Keeps architecture consistent with existing command pattern: strict local normalization + MCP-first behavior + REST fallback where appropriate.
- Reduces user risk with clear validation failures before API calls and safe, actionable runtime errors.

Closes #28

## Tests
- `bun test`
- `./calendly --help`
- `./calendly schedule-event --help`
- `./calendly --help | rg -n "schedule-event|schedule_event"`

All passed locally.

## AI Assistance
- Used: Yes (Codex CLI)
- Testing level: Local automated tests + manual help/CLI checks
- Prompt/session log link: Local Codex session (no public URL)
- I understand this code.
