### PR TITLE
Add PATH installer for calendly CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ Thumbs.db
 *.swp
 *.swo
 *~
+
+# Local review tooling
+compound-engineering.local.md

--- a/README.md
+++ b/README.md
@@ -15,12 +15,21 @@ Moltbot skill for Calendly integration. List events, check availability, manage 
 
 ```bash
 # Clone the repo
-git clone https://github.com/kesslerio/calendly-moltbot-skill.git
-cd calendly-moltbot-skill
+git clone https://github.com/kesslerio/calendly-cli-openclaw-skill.git
+cd calendly-cli-openclaw-skill
 
-# The CLI is self-contained (generated via mcporter from MCP server)
-chmod +x calendly
+# Install the launcher on PATH
+bun run install:path
+
+# If needed, add ~/.local/bin to PATH
+export PATH="$HOME/.local/bin:$PATH"
+
+# Verify the install
+command -v calendly
+calendly --help
 ```
+
+The installer creates `~/.local/bin/calendly` by default. Override the target dir with `bun run install:path -- --bin-dir /your/bin/dir`.
 
 ## Configuration
 
@@ -37,13 +46,13 @@ Get your token from: https://calendly.com/integrations/api_webhooks
 ### Get Your Profile
 
 ```bash
-./calendly get-current-user
+calendly get-current-user
 ```
 
 ### List Events
 
 ```bash
-./calendly list-events \
+calendly list-events \
   --user-uri "<YOUR_USER_URI>" \
   --min-start-time "2026-01-20T00:00:00Z" \
   --max-start-time "2026-01-27T23:59:59Z"
@@ -52,7 +61,7 @@ Get your token from: https://calendly.com/integrations/api_webhooks
 ### List Events with Invitees (Single Call)
 
 ```bash
-./calendly list-events --status active --include-invitees
+calendly list-events --status active --include-invitees
 ```
 
 This command first fetches events with Calendly `expand=invitees`. When Calendly reports `invitees_counter.active > 0` but embedded `invitees` are missing/empty, CLI falls back to `scheduled_events/{event_uuid}/invitees` for those events.
@@ -61,7 +70,7 @@ Fallback controls:
 - `--max-invitee-fetches <number>`: hard cap for fallback invitee fetch calls (default: `25`)
 
 Response metadata includes `meta.invitee_hydration` with fallback usage and truncation signals such as `truncated`, `events_skipped_due_to_cap`, and `truncation_reason`.
-Backward-compatible alias still works: `./calendly list-events-with-invitees --status active`.
+Backward-compatible alias still works: `calendly list-events-with-invitees --status active`.
 
 Date-range validation rules for `list-events`, `list-events-with-invitees`, `search-invitees`, and `search-team`:
 - `--min-start-time` and `--max-start-time` must be ISO-8601 timestamps (example: `2026-01-20T00:00:00Z`)
@@ -71,7 +80,7 @@ Date-range validation rules for `list-events`, `list-events-with-invitees`, `sea
 ### Search Invitees by Email
 
 ```bash
-./calendly search-invitees --email "person@example.com" --organization-uri "<YOUR_ORG_URI>"
+calendly search-invitees --email "person@example.com" --organization-uri "<YOUR_ORG_URI>"
 ```
 
 Supports pagination with `--page-size` and `--max-pages` for large orgs.
@@ -79,7 +88,7 @@ Supports pagination with `--page-size` and `--max-pages` for large orgs.
 ### Search Team Calendars by Invitee Email
 
 ```bash
-./calendly search-team --email "person@example.com" --organization-uri "<YOUR_ORG_URI>" --count 25 --max-membership-pages 10
+calendly search-team --email "person@example.com" --organization-uri "<YOUR_ORG_URI>" --count 25 --max-membership-pages 10
 ```
 
 This command resolves team members from organization memberships, scans each member's events in bounded pages, and returns matching events with member context.
@@ -88,7 +97,7 @@ This command resolves team members from organization memberships, scans each mem
 ### List Team Events
 
 ```bash
-./calendly list-team-events \
+calendly list-team-events \
   --organization-uri "<YOUR_ORG_URI>" \
   --min-start-time "2026-01-20T00:00:00Z" \
   --max-start-time "2026-01-27T23:59:59Z" \
@@ -102,7 +111,7 @@ Use `--include-invitees` when you want invitee details in the same response.
 ### Batch Invitee Lookup by Event URI
 
 ```bash
-./calendly batch-event-invitees \
+calendly batch-event-invitees \
   --event-uri "https://api.calendly.com/scheduled_events/<EVENT_UUID_1>" \
   --event-uri "https://api.calendly.com/scheduled_events/<EVENT_UUID_2>" \
   --max-invitee-fetches 25
@@ -118,7 +127,7 @@ Supports repeated `--event-uri` flags plus `--raw` JSON (`event_uri` or `event_u
 ### Get Event Type Availability
 
 ```bash
-./calendly get-event-type-availability \
+calendly get-event-type-availability \
   --event-type-uri "https://api.calendly.com/event_types/<EVENT_TYPE_UUID>" \
   --start-time "2026-03-01T00:00:00Z" \
   --end-time "2026-03-02T00:00:00Z" \
@@ -136,7 +145,7 @@ Validation rules:
 ### List Event Types
 
 ```bash
-./calendly list-event-types \
+calendly list-event-types \
   --organization-uri "https://api.calendly.com/organizations/<ORG_UUID>" \
   --count 20 \
   -o json
@@ -149,7 +158,7 @@ Validation rules:
 ### Get Event Type Details
 
 ```bash
-./calendly get-event-type \
+calendly get-event-type \
   --event-type-uri "https://api.calendly.com/event_types/<EVENT_TYPE_UUID>" \
   -o json
 ```
@@ -160,7 +169,7 @@ Validation rules:
 ### Update Event Type
 
 ```bash
-./calendly update-event-type \
+calendly update-event-type \
   --event-type-uri "https://api.calendly.com/event_types/<EVENT_TYPE_UUID>" \
   --duration 30 \
   --active true \
@@ -170,7 +179,7 @@ Validation rules:
 Dry-run example:
 
 ```bash
-./calendly update-event-type \
+calendly update-event-type \
   --event-type-uuid "<EVENT_TYPE_UUID>" \
   --description "Updated invitee-facing description" \
   --dry-run \
@@ -198,7 +207,7 @@ Response shape:
 ### Schedule Event
 
 ```bash
-./calendly schedule-event \
+calendly schedule-event \
   --event-type "https://api.calendly.com/event_types/<EVENT_TYPE_UUID>" \
   --start-time "2099-03-01T15:00:00Z" \
   --invitee-email "invitee@example.com" \
@@ -232,7 +241,7 @@ Response includes normalized booking details when available:
 ### Reschedule Event
 
 ```bash
-./calendly reschedule-event \
+calendly reschedule-event \
   --event-uuid "<EVENT_UUID>" \
   --new-start-time "2099-03-02T16:00:00Z" \
   --reason "Conflict with another meeting" \
@@ -261,20 +270,20 @@ Response includes normalized reschedule details when available:
 ### Get Event Details
 
 ```bash
-./calendly get-event --event-uuid "<EVENT_UUID>"
+calendly get-event --event-uuid "<EVENT_UUID>"
 ```
 
 ### Cancel Event
 
 ```bash
-./calendly cancel-event --event-uuid "<EVENT_UUID>" --reason "Rescheduling needed"
+calendly cancel-event --event-uuid "<EVENT_UUID>" --reason "Rescheduling needed"
 ```
 
 ### Webhook Subscriptions
 
 ```bash
 # Create
-./calendly create-webhook-subscription \
+calendly create-webhook-subscription \
   --url "https://example.com/calendly/webhooks" \
   --events "invitee.created,invitee.canceled" \
   --organization-uri "https://api.calendly.com/organizations/<ORG_UUID>" \
@@ -282,15 +291,15 @@ Response includes normalized reschedule details when available:
   --signing-key "$CALENDLY_WEBHOOK_SIGNING_KEY"
 
 # List
-./calendly list-webhook-subscriptions \
+calendly list-webhook-subscriptions \
   --organization-uri "https://api.calendly.com/organizations/<ORG_UUID>"
 
 # Get
-./calendly get-webhook-subscription \
+calendly get-webhook-subscription \
   --webhook-subscription-uri "https://api.calendly.com/webhook_subscriptions/<SUBSCRIPTION_UUID>"
 
 # Delete
-./calendly delete-webhook-subscription \
+calendly delete-webhook-subscription \
   --webhook-subscription-uri "https://api.calendly.com/webhook_subscriptions/<SUBSCRIPTION_UUID>"
 ```
 
@@ -388,7 +397,7 @@ EOF
 MCPORTER_CONFIG=./mcporter.json npx mcporter@latest generate-cli --server calendly --output src/generated/cli.ts
 ```
 
-The public `./calendly` launcher stays stable and loads the handwritten `src/cli.ts` composition entrypoint, which in turn imports the generated `src/generated/cli.ts` artifact.
+The repo ships a stable `calendly` launcher. Symlink it into `~/.local/bin/calendly` to make the command available on PATH, and it will load the handwritten `src/cli.ts` composition entrypoint, which in turn imports the generated `src/generated/cli.ts` artifact.
 
 ## License
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -12,6 +12,11 @@ Interact with Calendly scheduling via MCP-generated CLI.
 ## Quick Start
 
 ```bash
+# Make the launcher available on PATH
+bun run install:path
+export PATH="$HOME/.local/bin:$PATH"
+command -v calendly
+
 # Get your Calendly profile (returns user URI)
 calendly get-current-user
 
@@ -27,6 +32,9 @@ calendly get-event --event-uuid <UUID>
 # Cancel an event
 calendly cancel-event --event-uuid <UUID> --reason "Rescheduling needed"
 ```
+
+Default install target: `~/.local/bin/calendly`.
+Override it with `bun run install:path -- --bin-dir /your/bin/dir`.
 
 ## Available Commands
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,12 @@
 {
   "name": "calendly-cli-openclaw-skill",
+  "bin": {
+    "calendly": "./calendly"
+  },
   "module": "index.ts",
+  "scripts": {
+    "install:path": "bun run ./scripts/install-path.ts"
+  },
   "type": "module",
   "private": true,
   "devDependencies": {

--- a/scripts/install-path.ts
+++ b/scripts/install-path.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env bun
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+	installCalendlyToPath,
+	parseInstallPathArgs,
+	renderInstallHelp,
+	renderInstallSummary,
+} from '../src/path-install';
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryDirectory = path.resolve(scriptDirectory, '..');
+
+async function main(): Promise<void> {
+	const args = parseInstallPathArgs(process.argv.slice(2));
+	if (args.help) {
+		console.log(renderInstallHelp());
+		return;
+	}
+
+	const outcome = await installCalendlyToPath(repositoryDirectory, args);
+	console.log(renderInstallSummary(outcome));
+}
+
+main().catch((error) => {
+	const message = error instanceof Error ? error.message : String(error);
+	console.error(message);
+	process.exit(1);
+});

--- a/src/path-install.test.ts
+++ b/src/path-install.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { lstat, mkdir, mkdtemp, readlink, rm, symlink, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+	defaultBinDir,
+	installCalendlyToPath,
+	parseInstallPathArgs,
+	pathIncludesDirectory,
+	renderInstallHelp,
+	renderInstallSummary,
+	resolveInstallTarget,
+} from './path-install';
+
+const temporaryDirectories: string[] = [];
+const originalPath = process.env.PATH;
+
+afterEach(async () => {
+	process.env.PATH = originalPath;
+	await Promise.allSettled(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+});
+
+async function createTempRepo(): Promise<string> {
+	const repositoryDirectory = await mkdtemp(path.join(os.tmpdir(), 'calendly-cli-install-'));
+	temporaryDirectories.push(repositoryDirectory);
+	await writeFile(path.join(repositoryDirectory, 'calendly'), '#!/usr/bin/env bun\n');
+	return repositoryDirectory;
+}
+
+describe('parseInstallPathArgs', () => {
+	test('parses --bin-dir and help flags', () => {
+		expect(parseInstallPathArgs(['--bin-dir', '/tmp/bin', '--help'])).toEqual({
+			binDir: '/tmp/bin',
+			help: true,
+		});
+	});
+
+	test('rejects unknown flags', () => {
+		expect(() => parseInstallPathArgs(['--wat'])).toThrow('Unknown argument: --wat');
+	});
+});
+
+describe('path install helpers', () => {
+	test('defaultBinDir points to ~/.local/bin', () => {
+		expect(defaultBinDir('/Users/example')).toBe('/Users/example/.local/bin');
+	});
+
+	test('resolveInstallTarget builds the symlink destination', () => {
+		expect(resolveInstallTarget('/repo', { binDir: '/tmp/bin' })).toEqual({
+			binDir: '/tmp/bin',
+			linkPath: '/tmp/bin/calendly',
+			sourcePath: '/repo/calendly',
+		});
+	});
+
+	test('pathIncludesDirectory matches normalized PATH entries', () => {
+		expect(pathIncludesDirectory('/usr/bin:/tmp/bin:/bin', '/tmp/bin')).toBe(true);
+		expect(pathIncludesDirectory('/usr/bin:/bin', '/tmp/bin')).toBe(false);
+	});
+
+	test('renderInstallHelp documents the installer entrypoints', () => {
+		expect(renderInstallHelp('/tmp/bin')).toContain('bun run install:path');
+		expect(renderInstallHelp('/tmp/bin')).toContain('default: /tmp/bin');
+	});
+});
+
+describe('installCalendlyToPath', () => {
+	test('creates a symlink in the target bin directory', async () => {
+		const repositoryDirectory = await createTempRepo();
+		const binDirectory = path.join(repositoryDirectory, 'bin');
+		process.env.PATH = binDirectory;
+
+		const outcome = await installCalendlyToPath(repositoryDirectory, { binDir: binDirectory });
+		const linkPath = path.join(binDirectory, 'calendly');
+		const stats = await lstat(linkPath);
+
+		expect(outcome.status).toBe('installed');
+		expect(stats.isSymbolicLink()).toBe(true);
+		expect(await readlink(linkPath)).toBe(path.join(repositoryDirectory, 'calendly'));
+		expect(renderInstallSummary(outcome)).toContain('already on PATH');
+	});
+
+	test('returns already-installed when the expected symlink already exists', async () => {
+		const repositoryDirectory = await createTempRepo();
+		const binDirectory = path.join(repositoryDirectory, 'bin');
+		await mkdir(binDirectory, { recursive: true });
+		await symlink(path.join(repositoryDirectory, 'calendly'), path.join(binDirectory, 'calendly'));
+
+		const outcome = await installCalendlyToPath(repositoryDirectory, { binDir: binDirectory });
+
+		expect(outcome.status).toBe('already-installed');
+	});
+
+	test('fails when a regular file already occupies the target path', async () => {
+		const repositoryDirectory = await createTempRepo();
+		const binDirectory = path.join(repositoryDirectory, 'bin');
+		await mkdir(binDirectory, { recursive: true });
+		await writeFile(path.join(binDirectory, 'calendly'), 'not a symlink');
+
+		await expect(
+			installCalendlyToPath(repositoryDirectory, { binDir: binDirectory })
+		).rejects.toThrow('non-symlink file already exists');
+	});
+});

--- a/src/path-install.ts
+++ b/src/path-install.ts
@@ -1,0 +1,160 @@
+import { mkdir, lstat, readlink, symlink } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+const DEFAULT_BIN_DIR_SEGMENTS = ['.local', 'bin'] as const;
+
+export interface InstallPathArgs {
+	binDir?: string;
+}
+
+export interface ParsedInstallPathArgs extends InstallPathArgs {
+	help: boolean;
+}
+
+export interface InstallTarget {
+	binDir: string;
+	linkPath: string;
+	sourcePath: string;
+}
+
+export interface InstallOutcome {
+	status: 'installed' | 'already-installed';
+	target: InstallTarget;
+	pathIncludesBinDir: boolean;
+}
+
+export function defaultBinDir(homeDirectory = os.homedir()): string {
+	return path.join(homeDirectory, ...DEFAULT_BIN_DIR_SEGMENTS);
+}
+
+export function parseInstallPathArgs(argv: string[]): ParsedInstallPathArgs {
+	const parsed: ParsedInstallPathArgs = {
+		binDir: undefined,
+		help: false,
+	};
+
+	for (let index = 0; index < argv.length; index += 1) {
+		const token = argv[index];
+		if (!token) {
+			continue;
+		}
+
+		if (token === '--help' || token === '-h') {
+			parsed.help = true;
+			continue;
+		}
+
+		if (token === '--bin-dir') {
+			const value = argv[index + 1];
+			if (!value) {
+				throw new Error('--bin-dir requires a value.');
+			}
+			parsed.binDir = value;
+			index += 1;
+			continue;
+		}
+
+		if (token.startsWith('--bin-dir=')) {
+			parsed.binDir = token.slice('--bin-dir='.length);
+			if (!parsed.binDir) {
+				throw new Error('--bin-dir requires a value.');
+			}
+			continue;
+		}
+
+		throw new Error(`Unknown argument: ${token}`);
+	}
+
+	return parsed;
+}
+
+export function resolveInstallTarget(repoDirectory: string, options: InstallPathArgs = {}): InstallTarget {
+	const sourcePath = path.resolve(repoDirectory, 'calendly');
+	const binDir = path.resolve(options.binDir ?? defaultBinDir());
+	return {
+		binDir,
+		linkPath: path.join(binDir, 'calendly'),
+		sourcePath,
+	};
+}
+
+export function pathIncludesDirectory(pathValue: string | undefined, directory: string): boolean {
+	if (!pathValue) {
+		return false;
+	}
+
+	const normalizedDirectory = path.resolve(directory);
+	return pathValue
+		.split(path.delimiter)
+		.filter(Boolean)
+		.some((entry) => path.resolve(entry) === normalizedDirectory);
+}
+
+export async function installCalendlyToPath(
+	repoDirectory: string,
+	options: InstallPathArgs = {}
+): Promise<InstallOutcome> {
+	const target = resolveInstallTarget(repoDirectory, options);
+
+	await mkdir(target.binDir, { recursive: true });
+
+	try {
+		const existing = await lstat(target.linkPath);
+		if (!existing.isSymbolicLink()) {
+			throw new Error(
+				`Cannot install ${target.linkPath} because a non-symlink file already exists there.`
+			);
+		}
+
+		const existingDestination = await readlink(target.linkPath);
+		const resolvedExistingDestination = path.resolve(target.binDir, existingDestination);
+		if (resolvedExistingDestination === target.sourcePath) {
+			return {
+				status: 'already-installed',
+				target,
+				pathIncludesBinDir: pathIncludesDirectory(process.env.PATH, target.binDir),
+			};
+		}
+
+		throw new Error(
+			`Cannot install ${target.linkPath} because it already points to ${resolvedExistingDestination}. Remove the existing symlink, then rerun the installer.`
+		);
+	} catch (error) {
+		const code = error && typeof error === 'object' && 'code' in error ? error.code : undefined;
+		if (code !== 'ENOENT') {
+			throw error;
+		}
+	}
+
+	await symlink(target.sourcePath, target.linkPath);
+
+	return {
+		status: 'installed',
+		target,
+		pathIncludesBinDir: pathIncludesDirectory(process.env.PATH, target.binDir),
+	};
+}
+
+export function renderInstallSummary(outcome: InstallOutcome): string {
+	const verb = outcome.status === 'installed' ? 'Installed' : 'Already installed';
+	const pathHint = outcome.pathIncludesBinDir
+		? `\n${outcome.target.binDir} is already on PATH. You can run: calendly --help`
+		: `\n${outcome.target.binDir} is not currently on PATH. Add it to your shell profile, then run: calendly --help`;
+
+	return `${verb} calendly at ${outcome.target.linkPath} -> ${outcome.target.sourcePath}${pathHint}`;
+}
+
+export function renderInstallHelp(defaultDirectory = defaultBinDir()): string {
+	return [
+		'Expose the local calendly CLI on PATH by creating a symlink.',
+		'',
+		'Usage:',
+		'  bun run install:path [--bin-dir <dir>]',
+		'  bun run ./scripts/install-path.ts [--bin-dir <dir>]',
+		'',
+		'Options:',
+		`  --bin-dir <dir>  Install into a specific bin directory (default: ${defaultDirectory})`,
+		'  -h, --help       Show this help output',
+	].join('\n');
+}


### PR DESCRIPTION
Closes #17

## What
- add a supported `bun run install:path` flow that symlinks the repo launcher into a bin directory
- add installer helper coverage for symlink creation, existing installs, and conflict handling
- update README and SKILL docs so `calendly` usage matches the actual install flow
- fix the stale repository clone URL in the README

## Why
The repo docs and skill examples assumed `calendly` was already on PATH, but the repo only shipped a local launcher. This change makes PATH exposure explicit and supported.

## Risk
Low. This is additive CLI install/documentation work and does not change Calendly API command behavior.

## How verified
- `bun test`
- `./calendly --help`
- `./calendly list-events --help`
- `bun run install:path --help`
- PATH smoke test with a temp bin dir resolving `calendly --help`
- `ce:review` on the current diff with no material findings

## Notes
- Browser testing is not applicable for this CLI/docs-only change.
- Live Calendly API smoke is not applicable because no Calendly command behavior changed.