### PR TITLE
feat: add create-event-type command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ Thumbs.db
 
 # Local review tooling
 compound-engineering.local.md
+.context/compound-engineering/feature-video/

--- a/README.md
+++ b/README.md
@@ -155,6 +155,37 @@ Validation rules:
 - at least one scope is required: `--user-uri` or `--organization-uri` (same in `--raw` mode)
 - `--count` is optional; when set, it must be an integer between 1 and 100
 
+### Create Event Type
+
+```bash
+calendly create-event-type \
+  --user-uri "https://api.calendly.com/users/<USER_UUID>" \
+  --name "CLI Smoke Test" \
+  --duration 30 \
+  --active false \
+  --location-kind zoom_conference \
+  -o json
+```
+
+Validation and behavior:
+- requires exactly one owner source: `--user-uri`, `--team-uri`, or `--raw {"owner":"..."}`
+- requires `--name`
+- requires at least one duration source: `--duration` or repeated `--duration-option`
+- when both `--duration` and `--duration-option` values are provided, `--duration` must match one of the declared duration options
+- `--active` requires explicit `true` or `false`; when omitted, Calendly's API default applies
+- `--color` must be a 6-digit hex color (example: `#fff200`)
+- `--locale` must be one of `de|en|es|fr|it|nl|pt|uk`
+- `--location-kind` supports Calendly's documented location kinds; `--location`, `--location-additional-info`, and `--location-phone-number` apply to that single location entry
+- `--raw` JSON supports advanced payloads such as `owner`, `duration_options`, full `locations` arrays, and `team_uri`
+- this command currently ships only documented create fields; issue-body flags like `--slug`, `--secret`, and buffer settings are intentionally not supported yet
+
+Response shape:
+- `query.owner`
+- `query.name`
+- optional normalized fields such as `duration`, `duration_options`, `locations`, `color`, and `locale`
+- `meta.created`
+- `resource` with the created event type details when Calendly returns a resource payload
+
 ### Get Event Type Details
 
 ```bash
@@ -321,6 +352,7 @@ Signing secret handling guidance:
 - `list-events` - List scheduled events (`--include-invitees` for expand + bounded fallback invitee hydration)
 - `list-events-with-invitees` - Compatibility alias for include-invitees path
 - `get-event` - Get event details
+- `create-event-type` - Create a new solo event type (requires one owner source plus duration configuration)
 - `list-event-types` - List available event types for scheduling (requires at least one of `--user-uri` or `--organization-uri`)
 - `get-event-type` - Get details for a specific event type (requires `--event-type-uri`)
 - `update-event-type` - Update mutable event type metadata (`--event-type-uri` primary, `--event-type-uuid` alias, supports `--dry-run`)
@@ -367,6 +399,7 @@ Then use in conversations:
 
 - `schedule-event` requires a paid Calendly plan (Standard or higher). Free plans receive `403`.
 - `reschedule-event` requires paid-plan API access and can fail with clear messages for invalid identifiers, unavailable target slots, or payload validation.
+- `create-event-type` mutates Calendly configuration and should be smoke-tested with a clearly labeled inactive event type when possible.
 - `update-event-type` mutates Calendly configuration. Use `--dry-run` first, then validate against a disposable test event type and revert the changed field after smoke testing.
 - Safe error messages are returned for common failures: invalid event type, unavailable slot, custom question validation, and plan restrictions.
 - For the most reliable bookings, fetch slots first via `get-event-type-availability` and then schedule exactly one returned `start_time`.

--- a/docs/plans/2026-03-25-001-feat-create-event-type-command-plan.md
+++ b/docs/plans/2026-03-25-001-feat-create-event-type-command-plan.md
@@ -1,0 +1,285 @@
+---
+title: feat: Add create-event-type command
+type: feat
+status: active
+date: 2026-03-25
+deepened: 2026-03-25
+---
+
+# feat: Add create-event-type command
+
+## Overview
+
+Add a handwritten `calendly create-event-type` command that creates Calendly event types using the documented Calendly MCP tool first and falls back to `POST /event_types` when MCP is unavailable. Ship a stable CLI around verified API fields instead of inventing undocumented create behavior.
+
+## Problem Frame
+
+Issue #29 asks for CLI creation of booking page templates so users can spin up new event types without using the Calendly UI. The repo already supports listing, fetching, updating, and checking availability for event types, so create is the missing piece in the event-type management set. The command needs to fit the repo's handwritten command overlay, preserve help routing, and keep REST fallback behavior aligned with existing command patterns.
+
+## Requirements Trace
+
+- R1. Add a new `create-event-type` command and `create_event_type` alias.
+- R2. Follow the existing handwritten event-type command pattern: dedicated query normalizer/shaper module, unit tests, MCP-first execution, REST fallback, and safe error messages.
+- R3. Support only create fields verified in Calendly's current API docs: `owner`, `name`, optional `active`, `description`, `duration`, `duration_options`, `locations`, `color`, and `locale`.
+- R4. Preserve owner ergonomics by accepting `--user-uri` and `--team-uri` and normalizing them into the API's `owner` field.
+- R5. Update CLI help, command routing, and README documentation for the new command.
+- R6. Run repo-required verification: tests, top-level help, command help, and live smoke validation when safe.
+
+## Scope Boundaries
+
+- Do not add undocumented create flags from the issue body such as `--slug`, `--secret`, `--buffer-before`, or `--buffer-after`.
+- Do not regenerate or hand-edit [`src/generated/cli.ts`](/Users/kesslerio/.codex/worktrees/787e/calendly-cli-openclaw-skill/src/generated/cli.ts); this change belongs in the handwritten overlay.
+- Do not broaden the command to team, collective, or round-robin event type creation; Calendly documents create as solo-only today.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- [`src/commands/register-event-types.ts`](/Users/kesslerio/.codex/worktrees/787e/calendly-cli-openclaw-skill/src/commands/register-event-types.ts): handwritten event-type commands, shared fetch helpers, MCP-first with REST fallback.
+- [`src/update-event-type.ts`](/Users/kesslerio/.codex/worktrees/787e/calendly-cli-openclaw-skill/src/update-event-type.ts): query normalization, payload shaping, and safe error mapping for an event-type write command.
+- [`src/update-event-type.test.ts`](/Users/kesslerio/.codex/worktrees/787e/calendly-cli-openclaw-skill/src/update-event-type.test.ts): test structure for normalization and result shaping.
+- [`src/commands/run-cli.ts`](/Users/kesslerio/.codex/worktrees/787e/calendly-cli-openclaw-skill/src/commands/run-cli.ts) and [`src/commands/program.ts`](/Users/kesslerio/.codex/worktrees/787e/calendly-cli-openclaw-skill/src/commands/program.ts): handwritten command routing, global help, and displayed signatures.
+- [`src/commands/register-webhooks.ts`](/Users/kesslerio/.codex/worktrees/787e/calendly-cli-openclaw-skill/src/commands/register-webhooks.ts): simple direct-write REST pattern when no dedicated helper module is needed.
+- [`src/commands/run-cli.test.ts`](/Users/kesslerio/.codex/worktrees/787e/calendly-cli-openclaw-skill/src/commands/run-cli.test.ts): already expects `create-event-type` help routing, so current repo behavior is incomplete.
+
+### Institutional Learnings
+
+- No `docs/solutions/` or prior repo-local learning docs were present for this topic.
+
+### External References
+
+- Calendly FAQ confirms event types can be created and managed via API: [developer.calendly.com/frequently-asked-questions](https://developer.calendly.com/frequently-asked-questions)
+- Calendly MCP tool list includes `event_types-create_event_type`: [developer.calendly.com/supported-tools](https://developer.calendly.com/supported-tools)
+- Calendly Create Event Type reference: [calendly.stoplight.io/docs/api-docs/nuowpx7qfagsc-create-event-type](https://calendly.stoplight.io/docs/api-docs/nuowpx7qfagsc-create-event-type)
+- Calendly Update Event Type reference, used for parity and field comparison: [calendly.stoplight.io/docs/api-docs/44f6bf7d769c8-update-event-type](https://calendly.stoplight.io/docs/api-docs/44f6bf7d769c8-update-event-type)
+
+## Key Technical Decisions
+
+- Implement this as a handwritten overlay command rather than editing generated CLI output.
+  Rationale: the repo already overlays event-type write behavior by hand, and the generated CLI file is explicitly marked `DO NOT EDIT`.
+- Keep the CLI surface tied to documented create fields and defer undocumented flags.
+  Rationale: the issue body proposes fields not present in Calendly's current create schema, and exposing them now would create a misleading, brittle contract.
+- Accept owner through issue-friendly flags and raw JSON, then normalize to a single `owner` URI in the payload.
+  Rationale: this keeps the CLI ergonomic without creating multiple backend code paths.
+- Expose a single-location CLI shape using documented location fields and reserve full multi-location arrays for `--raw`.
+  Rationale: the API accepts a `locations` array, but a first-pass handwritten CLI should stay small and predictable while still allowing advanced payloads through raw JSON.
+- Require an explicit duration source from flags or raw input instead of relying on undocumented server defaults.
+  Rationale: the API exposes both `duration` and `duration_options`, and a create command should produce an intentionally configured event type.
+- Use MCP first and REST fallback.
+  Rationale: this matches repo policy and keeps behavior consistent with existing event-type commands.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should this command be generated or handwritten?
+  Resolution: handwritten, to match the existing event-type overlay pattern and avoid editing generated code.
+- Should undocumented issue-body flags be added anyway?
+  Resolution: no. The initial command will expose only verified fields.
+- Should external research be used?
+  Resolution: yes. This touches an external API and public CLI surface, so current official docs were checked.
+
+### Deferred to Implementation
+
+- Exact MCP proxy method name and response shape for event type creation.
+  Deferred because the practical answer depends on the runtime proxy exposed by `mcporter`; implementation will probe it and keep REST fallback as the backstop.
+- Whether live smoke validation is safe with the current `CALENDLY_API_KEY`.
+  Deferred because safety depends on the actual account behind the token and whether creating an inactive disposable event type is acceptable.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+sequenceDiagram
+    participant CLI as Commander CLI
+    participant Normalize as create-event-type.ts
+    participant MCP as Calendly MCP proxy
+    participant REST as Calendly REST API
+    participant Output as output.ts
+
+    CLI->>Normalize: parse flags + raw JSON
+    Normalize-->>CLI: normalized query + payload helpers
+    CLI->>MCP: createEventType(normalized MCP args)
+    alt MCP returns usable resource
+        CLI->>Output: print shaped result
+    else MCP unavailable, times out, or returns unusable shape
+        CLI->>REST: POST /event_types with shaped JSON body
+        REST-->>CLI: created resource
+        CLI->>Output: print shaped result
+    end
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Add create-event-type query normalization and result shaping**
+
+**Goal:** Create the reusable normalization, payload, shaping, and error-mapping layer for event type creation.
+
+**Requirements:** R2, R3, R4
+
+**Dependencies:** None
+
+**Files:**
+- Create: [`src/create-event-type.ts`](/Users/kesslerio/.codex/worktrees/787e/calendly-cli-openclaw-skill/src/create-event-type.ts)
+- Test: [`src/create-event-type.test.ts`](/Users/kesslerio/.codex/worktrees/787e/calendly-cli-openclaw-skill/src/create-event-type.test.ts)
+
+**Approach:**
+- Define a dedicated command options type and normalized query shape.
+- Normalize owner from flags and `--raw`, rejecting missing or conflicting owner sources.
+- Validate create fields against documented constraints such as hex color pattern, locale enum, duration bounds, and owner/name presence.
+- Support either one explicit `duration` or one-or-more `duration_options`; reject calls that provide neither.
+- Support one-location convenience flags (`location_kind`, `location`, `location_additional_info`, `location_phone_number`) and reserve raw arrays for advanced `locations` payloads.
+- Build helper functions for MCP args, REST body shaping, result shaping, and safe error mapping.
+- Keep the module focused on value normalization and API contract shaping only.
+
+**Execution note:** Implement new domain behavior test-first.
+
+**Patterns to follow:**
+- [`src/update-event-type.ts`](/Users/kesslerio/.codex/worktrees/787e/calendly-cli-openclaw-skill/src/update-event-type.ts)
+- [`src/update-event-type.test.ts`](/Users/kesslerio/.codex/worktrees/787e/calendly-cli-openclaw-skill/src/update-event-type.test.ts)
+
+**Test scenarios:**
+- Normalizes `--user-uri` or `--team-uri` into `owner`.
+- Rejects missing owner, conflicting owner inputs, invalid color, invalid locale, and invalid duration values.
+- Rejects missing duration sources and invalid `duration_options` collections.
+- Normalizes one-location convenience flags into a single-entry `locations` array.
+- Shapes REST and MCP payloads consistently.
+- Converts common API failures into safe CLI-facing error strings.
+- Shapes successful API responses into stable output with `query`, `meta`, and `resource`.
+
+**Verification:**
+- The helper module can be used by the command without inline validation logic, and unit tests cover both successful normalization and failure paths.
+
+- [ ] **Unit 2: Register the handwritten create-event-type command**
+
+**Goal:** Expose the new command through the handwritten CLI overlay with MCP-first execution and REST fallback.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: [`src/commands/register-event-types.ts`](/Users/kesslerio/.codex/worktrees/787e/calendly-cli-openclaw-skill/src/commands/register-event-types.ts)
+
+**Approach:**
+- Import the new helper module beside the existing event-type helpers.
+- Add a `create-event-type` command with help text, alias, required/optional flags, and raw JSON support.
+- Keep the flag set aligned with verified docs: `--name`, owner flags, `--duration`, repeated `--duration-option`, `--active`, `--description`, `--color`, `--locale`, and the single-location convenience flags.
+- Attempt the Calendly MCP create tool first using the normalized payload.
+- If MCP fails or returns an unusable shape, fall back to REST `POST https://api.calendly.com/event_types`.
+- Print shaped output on success and safe error output on failure.
+
+**Patterns to follow:**
+- [`src/commands/register-event-types.ts`](/Users/kesslerio/.codex/worktrees/787e/calendly-cli-openclaw-skill/src/commands/register-event-types.ts)
+- [`src/commands/register-webhooks.ts`](/Users/kesslerio/.codex/worktrees/787e/calendly-cli-openclaw-skill/src/commands/register-webhooks.ts)
+- [`src/commands/runtime.ts`](/Users/kesslerio/.codex/worktrees/787e/calendly-cli-openclaw-skill/src/commands/runtime.ts)
+
+**Test scenarios:**
+- Help text includes the new command usage and example.
+- A normalization failure exits with a safe error.
+- REST fallback path uses the shaped body and still prints the normalized result shape.
+- MCP fallback is only triggered on actual MCP failure or unusable MCP output, not on a successful shaped resource.
+- Solo-only and insufficient-scope failures are surfaced clearly.
+
+**Verification:**
+- Running command help shows the new command, and the command can execute successfully through at least one of MCP or REST.
+
+- [ ] **Unit 3: Wire routing, signatures, and top-level help**
+
+**Goal:** Make the new handwritten command discoverable in CLI routing and help output.
+
+**Requirements:** R1, R5
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: [`src/commands/program.ts`](/Users/kesslerio/.codex/worktrees/787e/calendly-cli-openclaw-skill/src/commands/program.ts)
+- Modify: [`src/commands/run-cli.ts`](/Users/kesslerio/.codex/worktrees/787e/calendly-cli-openclaw-skill/src/commands/run-cli.ts)
+- Modify: [`src/commands/run-cli.test.ts`](/Users/kesslerio/.codex/worktrees/787e/calendly-cli-openclaw-skill/src/commands/run-cli.test.ts)
+
+**Approach:**
+- Add the displayed function signature for `create-event-type`.
+- Add both kebab-case and snake_case command names to handwritten command routing.
+- Extend top-level handwritten help output so the command is visible even when generated CLI help is used as the base.
+- Add or update tests where routing/help assumptions need to become explicit.
+
+**Patterns to follow:**
+- [`src/commands/program.ts`](/Users/kesslerio/.codex/worktrees/787e/calendly-cli-openclaw-skill/src/commands/program.ts)
+- [`src/commands/run-cli.ts`](/Users/kesslerio/.codex/worktrees/787e/calendly-cli-openclaw-skill/src/commands/run-cli.ts)
+- [`src/commands/run-cli.test.ts`](/Users/kesslerio/.codex/worktrees/787e/calendly-cli-openclaw-skill/src/commands/run-cli.test.ts)
+
+**Test scenarios:**
+- Command detection recognizes `create-event-type` after global flags.
+- Help target rewrite keeps working for `help create-event-type`.
+- Global help no longer hides the new handwritten command.
+
+**Verification:**
+- Top-level help and help routing both expose the command consistently.
+
+- [ ] **Unit 4: Document the command and verify the shipped behavior**
+
+**Goal:** Align user-facing docs and complete the repo's verification gate for the new command.
+
+**Requirements:** R5, R6
+
+**Dependencies:** Units 1-3
+
+**Files:**
+- Modify: [`README.md`](/Users/kesslerio/.codex/worktrees/787e/calendly-cli-openclaw-skill/README.md)
+
+**Approach:**
+- Add a README section for `create-event-type` with examples and clearly documented supported fields.
+- Document any intentional exclusions from the issue body so the CLI contract is honest.
+- Prefer examples that create inactive or clearly labeled synthetic event types to reduce risk during manual smoke validation.
+- Run repo-required validation: tests, general help, command help, and live smoke validation when safe.
+
+**Patterns to follow:**
+- Existing event-type sections in [`README.md`](/Users/kesslerio/.codex/worktrees/787e/calendly-cli-openclaw-skill/README.md)
+
+**Test scenarios:**
+- README example matches the implemented flags.
+- Help output reflects the documented interface.
+- Live smoke validation uses a synthetic, clearly labeled inactive event type if it is safe to do so.
+
+**Verification:**
+- Docs and help agree with the implementation, and verification results are recorded before review/PR completion.
+
+## System-Wide Impact
+
+- **Interaction graph:** affects the handwritten command registration path, top-level command routing, command signature display, and README command inventory.
+- **Error propagation:** normalization failures should surface as safe user-facing errors before any network call; MCP failures should fall through to REST; REST failures should be sanitized before printing.
+- **State lifecycle risks:** this is a mutative API command. Live smoke validation must avoid creating noisy production-facing event types where possible.
+- **Fallback parity:** result shaping must hide whether success came from MCP or REST so downstream users get one stable output contract.
+- **API surface parity:** top-level help, command-specific help, README docs, and the handwritten routing set all need the same command name.
+- **Integration coverage:** unit tests prove normalization and shaping, but only a live smoke test can prove the upstream create contract still accepts the emitted payload.
+
+## Risks & Dependencies
+
+- Calendly currently documents create as solo-only; org-owned or pooled event type creation may fail even if the CLI accepts an owner URI string.
+- MCP and REST may not return identical payload shapes, so the shaper must tolerate both wrapped and direct resource responses.
+- The issue body includes undocumented create options; adding them later may require a backward-compatible expansion of the command surface.
+- Live smoke validation may be unsafe on a real user account if no disposable owner context exists.
+
+## Alternative Approaches Considered
+
+- Implement the issue body's proposed flags exactly, including undocumented create fields.
+  Rejected because the official March 25, 2026 create schema does not document `slug`, `secret`, or buffer settings, so exposing them now would create a misleading CLI contract.
+- Use REST only and skip the MCP path.
+  Rejected because repo guidance prefers MCP-first execution where supported, and Calendly's official MCP tool list now includes create-event-type support.
+- Edit or regenerate the generated CLI and stop using the handwritten overlay for event-type writes.
+  Rejected because the repo already routes event-type write behavior through handwritten modules, and touching generated output would make the change harder to reason about and maintain.
+
+## Documentation / Operational Notes
+
+- README must be updated in the same change because this introduces public CLI behavior.
+- If live smoke validation is skipped, the final implementation summary should explain exactly why it was unsafe or unavailable.
+- Review should explicitly check that global help and command help still work in both handwritten and generated-help code paths.
+
+## Sources & References
+
+- Related issue: #29
+- Related code: [`src/commands/register-event-types.ts`](/Users/kesslerio/.codex/worktrees/787e/calendly-cli-openclaw-skill/src/commands/register-event-types.ts)
+- Related code: [`src/update-event-type.ts`](/Users/kesslerio/.codex/worktrees/787e/calendly-cli-openclaw-skill/src/update-event-type.ts)
+- External docs: [https://developer.calendly.com/supported-tools](https://developer.calendly.com/supported-tools)
+- External docs: [https://calendly.stoplight.io/docs/api-docs/nuowpx7qfagsc-create-event-type](https://calendly.stoplight.io/docs/api-docs/nuowpx7qfagsc-create-event-type)

--- a/src/commands/program.ts
+++ b/src/commands/program.ts
@@ -19,6 +19,8 @@ const commandSignatures: Record<string, string> = {
 	'get-oauth-url': 'function get_oauth_url(redirect_uri: string, state?: string);',
 	'exchange-code-for-tokens': 'function exchange_code_for_tokens(code: string, redirect_uri: string);',
 	'refresh-access-token': 'function refresh_access_token(refresh_token: string);',
+	'create-event-type':
+		'function create_event_type(owner: string, name: string, duration?: number, duration_options?: number[], active?: boolean, description?: string, locations?: { kind: string, location?: string, additional_info?: string, phone_number?: string }[], color?: string, locale?: "de" | "en" | "es" | "fr" | "it" | "nl" | "pt" | "uk");',
 	'list-event-types': 'function list_event_types(user?: string, organization?: string, count?: number);',
 	'get-event-type': 'function get_event_type(event_type: string);',
 	'update-event-type':

--- a/src/commands/register-event-types.ts
+++ b/src/commands/register-event-types.ts
@@ -1,5 +1,12 @@
 import { createCallResult } from 'mcporter';
 import { Command } from 'commander';
+import {
+	normalizeCreateEventTypeQuery,
+	shapeCreateEventTypeResult,
+	toCreateEventTypeMcpArgs,
+	toCreateEventTypeRestBody,
+	toSafeCreateEventTypeError,
+} from '../create-event-type';
 import { normalizeEventTypeAvailabilityQuery, shapeEventTypeAvailabilityResult } from '../event-type-availability';
 import { extractEventTypeUuid, normalizeGetEventTypeQuery, shapeGetEventTypeResult } from '../get-event-type';
 import { normalizeListEventTypesQuery, shapeListEventTypesResult, toListEventTypesMcpArgs } from '../list-event-types';
@@ -39,6 +46,10 @@ function parseBooleanFlag(value: string, optionName: string): boolean {
 		return false;
 	}
 	throw new Error(`Invalid ${optionName} value "${value}". Use true or false.`);
+}
+
+function collectIntegerFlag(value: string, previous: number[] | undefined, optionName: string): number[] {
+	return [...(previous ?? []), parseIntegerFlag(value, optionName)];
 }
 
 async function calendlyRequest(
@@ -140,7 +151,104 @@ async function fetchUpdateEventTypeResult(query: Record<string, unknown>, timeou
 	return shapeUpdateEventTypeResult(data as Record<string, unknown>, query as any);
 }
 
+async function fetchCreateEventTypeResult(query: Record<string, unknown>, timeout: number): Promise<unknown> {
+	const apiKey = requireApiKey();
+	const data = await calendlyRequest('https://api.calendly.com/event_types', apiKey, timeout, {
+		method: 'POST',
+		body: JSON.stringify(toCreateEventTypeRestBody(query as any)),
+	});
+	return shapeCreateEventTypeResult(data as Record<string, unknown>, query as any);
+}
+
 export function registerEventTypeCommands(program: Command): void {
+	program
+		.command('create-event-type')
+		.summary(
+			'create-event-type (--user-uri <user-uri> | --team-uri <team-uri> | --raw <json>) --name <name> [--duration <duration:number>] [--duration-option <duration-option:number>] [--active <active:boolean>] [--description <description>] [--color <color>] [--locale <locale>] [--location-kind <location-kind>] [--location <location>] [--location-additional-info <location-additional-info>] [--location-phone-number <location-phone-number>]'
+		)
+		.description('Create a new solo event type')
+		.usage(
+			'(--user-uri <user-uri> | --team-uri <team-uri> | --raw <json>) --name <name> [--duration <duration:number>] [--duration-option <duration-option:number>] [--active <active:boolean>] [--description <description>] [--color <color>] [--locale <locale>] [--location-kind <location-kind>] [--location <location>] [--location-additional-info <location-additional-info>] [--location-phone-number <location-phone-number>]'
+		)
+		.option('--raw <json>', 'Provide raw JSON arguments to the tool, bypassing flag parsing.')
+		.option('--user-uri <user-uri>', 'User URI to use as the event type owner')
+		.option('--team-uri <team-uri>', 'Team URI to use as the event type owner')
+		.option('--name <name>', 'Event type display name')
+		.option('--duration <duration:number>', 'Primary event duration in minutes (1-720)', (value) => parseIntegerFlag(value, 'duration'))
+		.option(
+			'--duration-option <duration-option:number>',
+			'Allowed duration option in minutes (repeat up to 4 times)',
+			(value, previous: number[] | undefined) => collectIntegerFlag(value, previous, 'duration-option'),
+			[]
+		)
+		.option('--active <active:boolean>', 'Whether the event type is active (true or false)', (value) => parseBooleanFlag(value, 'active'))
+		.option('--description <description>', 'Invitee-facing event type description')
+		.option('--color <color>', 'Scheduling page brand color in hex format (example: #fff200)')
+		.option('--locale <locale>', 'Scheduling page locale (de|en|es|fr|it|nl|pt|uk)')
+		.option('--location-kind <location-kind>', 'Single location kind to attach to the event type')
+		.option('--location <location>', 'Single location value such as a physical address or custom label')
+		.option('--location-additional-info <location-additional-info>', 'Additional location details for the single location entry')
+		.option('--location-phone-number <location-phone-number>', 'Phone number for inbound/outbound call locations')
+		.alias('create_event_type')
+		.action(async (cmdOpts) => {
+			const globalOptions = program.opts();
+			const timeout = globalOptions.timeout || 30000;
+			const rawArgs = cmdOpts.raw ? JSON.parse(cmdOpts.raw) : ({} as Record<string, unknown>);
+			let query: Record<string, unknown>;
+			try {
+				query = normalizeCreateEventTypeQuery(cmdOpts, rawArgs) as unknown as Record<string, unknown>;
+			} catch (error) {
+				console.error(`Error: ${toSafeCreateEventTypeError(error)}`);
+				process.exit(1);
+				return;
+			}
+
+			let mcpResult: unknown;
+			let mcpErrorMessage: string | undefined;
+			try {
+				const runtime = await ensureRuntime();
+				const proxy = getServerProxy(runtime) as any;
+				try {
+					const call = proxy.createEventType(toCreateEventTypeMcpArgs(query as any));
+					mcpResult = await invokeWithTimeout(call, timeout);
+					const mcpRaw = createCallResult(mcpResult).raw as Record<string, unknown> | undefined;
+					if (mcpRaw) {
+						const shaped = shapeCreateEventTypeResult(mcpRaw, query as any);
+						if (shaped.resource) {
+							printResult(shaped, globalOptions.output ?? 'text');
+							return;
+						}
+					}
+					printMcpResult(mcpResult, globalOptions.output ?? 'text');
+					return;
+				} catch (error) {
+					mcpErrorMessage = error instanceof Error ? error.message : String(error);
+				} finally {
+					await runtime.close(SERVER_NAME).catch(() => {});
+				}
+			} catch (error) {
+				mcpErrorMessage = error instanceof Error ? error.message : String(error);
+			}
+
+			try {
+				const restResult = await fetchCreateEventTypeResult(query, timeout);
+				printResult(restResult, globalOptions.output ?? 'text');
+			} catch (error) {
+				let message = toSafeCreateEventTypeError(error);
+				if (mcpErrorMessage) {
+					message = `${message} (MCP tool fallback failed: ${mcpErrorMessage})`;
+				}
+				console.error(`Error: ${message}`);
+				process.exit(1);
+			}
+		})
+		.addHelpText(
+			'after',
+			() =>
+				'\nExample:\n  ' +
+				'./calendly create-event-type --user-uri https://api.calendly.com/users/USER_123 --name "CLI Smoke Test" --duration 30 --active false --location-kind zoom_conference'
+		);
+
 	program
 		.command('list-event-types')
 		.summary('list-event-types (--user-uri <user-uri> | --organization-uri <organization-uri>) [--count <count:number>] [--raw <json>]')

--- a/src/commands/run-cli.ts
+++ b/src/commands/run-cli.ts
@@ -19,6 +19,8 @@ const HANDWRITTEN_COMMANDS = new Set([
 	'exchange_code_for_tokens',
 	'refresh-access-token',
 	'refresh_access_token',
+	'create-event-type',
+	'create_event_type',
 	'list-event-types',
 	'list_event_types',
 	'get-event-type',
@@ -171,6 +173,9 @@ function isMissingGeneratedCliDependency(error: unknown): boolean {
 
 function printHandwrittenHelpAddendum(): void {
 	console.log('\nHandwritten extensions:');
+	console.log(
+		'  create-event-type (--user-uri <user-uri> | --team-uri <team-uri> | --raw <json>) --name <name> [--duration <duration:number>] [--duration-option <duration-option:number>] [--active <active:boolean>] [--description <description>] [--color <color>] [--locale <locale>] [--location-kind <location-kind>] [--location <location>] [--location-additional-info <location-additional-info>] [--location-phone-number <location-phone-number>]'
+	);
 	console.log(
 		'  update-event-type (--event-type-uri <event-type-uri> | --event-type-uuid <event-type-uuid>) [--name <name>] [--description <description>] [--duration <duration:number>] [--active <active:boolean>] [--secret <secret:boolean>] [--dry-run] [--raw <json>]'
 	);

--- a/src/create-event-type.test.ts
+++ b/src/create-event-type.test.ts
@@ -1,0 +1,329 @@
+import { describe, expect, test } from 'bun:test';
+import {
+	normalizeCreateEventTypeQuery,
+	shapeCreateEventTypeResult,
+	toCreateEventTypeMcpArgs,
+	toCreateEventTypeRestBody,
+	toSafeCreateEventTypeError,
+} from './create-event-type';
+
+describe('normalizeCreateEventTypeQuery', () => {
+	test('normalizes user owner, duration, and optional fields from flags', () => {
+		const query = normalizeCreateEventTypeQuery({
+			userUri: ' https://api.calendly.com/users/USER_123 ',
+			name: ' Demo Call ',
+			duration: '30',
+			active: 'true',
+			color: '#FFF200',
+			locale: 'DE',
+		});
+
+		expect(query).toEqual({
+			owner: 'https://api.calendly.com/users/USER_123',
+			name: 'Demo Call',
+			duration: 30,
+			active: true,
+			color: '#fff200',
+			locale: 'de',
+		});
+	});
+
+	test('supports raw owner, duration options, and raw locations', () => {
+		const query = normalizeCreateEventTypeQuery(
+			{
+				name: 'Partner Intro',
+			},
+			{
+				owner: 'https://api.calendly.com/teams/TEAM_123',
+				duration_options: ['15', 30],
+				locations: [
+					{
+						kind: 'zoom_conference',
+					},
+					{
+						kind: 'physical',
+						location: 'HQ',
+						additional_info: 'Suite 300',
+					},
+				],
+			}
+		);
+
+		expect(query).toEqual({
+			owner: 'https://api.calendly.com/teams/TEAM_123',
+			name: 'Partner Intro',
+			duration_options: [15, 30],
+			locations: [
+				{ kind: 'zoom_conference' },
+				{ kind: 'physical', location: 'HQ', additional_info: 'Suite 300' },
+			],
+		});
+	});
+
+	test('supports single-location convenience flags', () => {
+		const query = normalizeCreateEventTypeQuery({
+			userUri: 'https://api.calendly.com/users/USER_123',
+			name: 'Onsite Visit',
+			duration: 45,
+			locationKind: 'physical',
+			location: '123 Main St',
+			locationAdditionalInfo: 'Lobby desk',
+		});
+
+		expect(query.locations).toEqual([
+			{
+				kind: 'physical',
+				location: '123 Main St',
+				additional_info: 'Lobby desk',
+			},
+		]);
+	});
+
+	test('supports team owner and raw convenience location fields', () => {
+		const query = normalizeCreateEventTypeQuery(
+			{
+				name: 'Team Handoff',
+			},
+			{
+				team_uri: 'https://api.calendly.com/teams/TEAM_123',
+				duration: 30,
+				location_kind: 'physical',
+				location: 'HQ',
+				location_additional_info: 'Front desk',
+			}
+		);
+
+		expect(query).toEqual({
+			owner: 'https://api.calendly.com/teams/TEAM_123',
+			name: 'Team Handoff',
+			duration: 30,
+			locations: [{ kind: 'physical', location: 'HQ', additional_info: 'Front desk' }],
+		});
+	});
+
+	test('rejects missing owner', () => {
+		expect(() =>
+			normalizeCreateEventTypeQuery({
+				name: 'Missing Owner',
+				duration: 30,
+			})
+		).toThrow('owner is required');
+	});
+
+	test('rejects conflicting owner sources', () => {
+		expect(() =>
+			normalizeCreateEventTypeQuery(
+				{
+					userUri: 'https://api.calendly.com/users/USER_123',
+					name: 'Conflict',
+					duration: 30,
+				},
+				{
+					owner: 'https://api.calendly.com/teams/TEAM_123',
+				}
+			)
+		).toThrow('provide exactly one owner source');
+	});
+
+	test('rejects organization URIs for owner inputs', () => {
+		expect(() =>
+			normalizeCreateEventTypeQuery({
+				name: 'Bad Owner',
+				duration: 30,
+			}, {
+				owner: 'https://api.calendly.com/organizations/ORG_123',
+			})
+		).toThrow('owner must be a Calendly user or team URI');
+	});
+
+	test('rejects missing duration sources', () => {
+		expect(() =>
+			normalizeCreateEventTypeQuery({
+				userUri: 'https://api.calendly.com/users/USER_123',
+				name: 'No Duration',
+			})
+		).toThrow('provide duration or duration_options');
+	});
+
+	test('rejects duration not present in duration options', () => {
+		expect(() =>
+			normalizeCreateEventTypeQuery({
+				userUri: 'https://api.calendly.com/users/USER_123',
+				name: 'Mismatch',
+				duration: 45,
+				durationOption: [15, 30],
+			})
+		).toThrow('duration must be one of the provided duration_options values');
+	});
+
+	test('rejects invalid color, locale, and location detail combinations', () => {
+		expect(() =>
+			normalizeCreateEventTypeQuery({
+				userUri: 'https://api.calendly.com/users/USER_123',
+				name: 'Bad Color',
+				duration: 30,
+				color: 'fff200',
+			})
+		).toThrow('color must be a hexadecimal color');
+
+		expect(() =>
+			normalizeCreateEventTypeQuery({
+				userUri: 'https://api.calendly.com/users/USER_123',
+				name: 'Bad Locale',
+				duration: 30,
+				locale: 'jp',
+			})
+		).toThrow('locale must be one of');
+
+		expect(() =>
+			normalizeCreateEventTypeQuery({
+				userUri: 'https://api.calendly.com/users/USER_123',
+				name: 'Missing Kind',
+				duration: 30,
+				location: 'HQ',
+			})
+		).toThrow('location_kind is required when providing location details');
+	});
+
+	test('rejects duplicate or oversized duration option collections', () => {
+		expect(() =>
+			normalizeCreateEventTypeQuery({
+				userUri: 'https://api.calendly.com/users/USER_123',
+				name: 'Duplicates',
+				durationOption: [15, 15],
+			})
+		).toThrow('duration_options values must be unique');
+
+		expect(() =>
+			normalizeCreateEventTypeQuery({
+				userUri: 'https://api.calendly.com/users/USER_123',
+				name: 'Too Many',
+				durationOption: [15, 30, 45, 60, 90],
+			})
+		).toThrow('duration_options cannot include more than 4 values');
+	});
+});
+
+describe('create event type payload builders', () => {
+	test('maps normalized query to MCP and REST payloads', () => {
+		const query = normalizeCreateEventTypeQuery({
+			userUri: 'https://api.calendly.com/users/USER_123',
+			name: 'Partner Call',
+			duration: 30,
+			active: false,
+			locationKind: 'zoom_conference',
+		});
+
+		expect(toCreateEventTypeMcpArgs(query)).toEqual({
+			owner: 'https://api.calendly.com/users/USER_123',
+			name: 'Partner Call',
+			duration: 30,
+			active: false,
+			locations: [{ kind: 'zoom_conference' }],
+		});
+
+		expect(toCreateEventTypeRestBody(query)).toEqual({
+			owner: 'https://api.calendly.com/users/USER_123',
+			name: 'Partner Call',
+			duration: 30,
+			active: false,
+			locations: [{ kind: 'zoom_conference' }],
+		});
+	});
+});
+
+describe('shapeCreateEventTypeResult', () => {
+	test('shapes wrapped resources', () => {
+		const query = normalizeCreateEventTypeQuery({
+			userUri: 'https://api.calendly.com/users/USER_123',
+			name: 'Partner Call',
+			duration: 30,
+		});
+
+		expect(
+			shapeCreateEventTypeResult(
+				{
+					resource: {
+						uri: 'https://api.calendly.com/event_types/ET_123',
+						name: 'Partner Call',
+						scheduling_url: 'https://calendly.com/acme/partner-call',
+					},
+				},
+				query
+			)
+		).toEqual({
+			query: {
+				owner: 'https://api.calendly.com/users/USER_123',
+				name: 'Partner Call',
+				duration: 30,
+			},
+			meta: {
+				created: true,
+			},
+			resource: {
+				uri: 'https://api.calendly.com/event_types/ET_123',
+				name: 'Partner Call',
+				scheduling_url: 'https://calendly.com/acme/partner-call',
+			},
+		});
+	});
+
+	test('supports direct resource payloads', () => {
+		const query = normalizeCreateEventTypeQuery({
+			userUri: 'https://api.calendly.com/users/USER_123',
+			name: 'Demo',
+			duration: 30,
+		});
+
+		expect(
+			shapeCreateEventTypeResult(
+				{
+					uri: 'https://api.calendly.com/event_types/ET_456',
+					name: 'Demo',
+					scheduling_url: 'https://calendly.com/acme/demo',
+				},
+				query
+			)
+		).toEqual({
+			query: {
+				owner: 'https://api.calendly.com/users/USER_123',
+				name: 'Demo',
+				duration: 30,
+			},
+			meta: {
+				created: true,
+			},
+			resource: {
+				uri: 'https://api.calendly.com/event_types/ET_456',
+				name: 'Demo',
+				scheduling_url: 'https://calendly.com/acme/demo',
+			},
+		});
+	});
+});
+
+describe('toSafeCreateEventTypeError', () => {
+	test('maps local validation, scope, auth, and generic failures to safe messages', () => {
+		expect(toSafeCreateEventTypeError(new Error('owner is required'))).toBe('owner is required');
+
+		expect(
+			toSafeCreateEventTypeError(
+				new Error('Calendly API request failed (403): {"title":"Insufficient scope","required_scopes":["event_types:write"]}')
+			)
+		).toBe('Your token is missing the event_types:write scope required to create event types.');
+
+		expect(
+			toSafeCreateEventTypeError(new Error('Calendly API request failed (401): {"title":"Unauthenticated"}'))
+		).toBe('Unable to authenticate with Calendly. Verify CALENDLY_API_KEY.');
+
+		expect(
+			toSafeCreateEventTypeError(
+				new Error('Calendly API request failed (400): {"message":"This endpoint only supports one-on-one event types (kind: \\"solo\\")"}')
+			)
+		).toBe('Calendly only allows creating solo event types through this endpoint.');
+
+		expect(toSafeCreateEventTypeError(new Error('something unexpected happened'))).toBe(
+			'Unable to create event type. Verify owner, requested fields, and token scope.'
+		);
+	});
+});

--- a/src/create-event-type.test.ts
+++ b/src/create-event-type.test.ts
@@ -136,6 +136,24 @@ describe('normalizeCreateEventTypeQuery', () => {
 		).toThrow('owner must be a Calendly user or team URI');
 	});
 
+	test('rejects mismatched user and team flag URI types', () => {
+		expect(() =>
+			normalizeCreateEventTypeQuery({
+				userUri: 'https://api.calendly.com/teams/TEAM_123',
+				name: 'Bad User Flag',
+				duration: 30,
+			})
+		).toThrow('user_uri must be a Calendly user URI');
+
+		expect(() =>
+			normalizeCreateEventTypeQuery({
+				teamUri: 'https://api.calendly.com/users/USER_123',
+				name: 'Bad Team Flag',
+				duration: 30,
+			})
+		).toThrow('team_uri must be a Calendly team URI');
+	});
+
 	test('rejects missing duration sources', () => {
 		expect(() =>
 			normalizeCreateEventTypeQuery({

--- a/src/create-event-type.ts
+++ b/src/create-event-type.ts
@@ -1,0 +1,422 @@
+export type CreateEventTypeCmdOptions = {
+	raw?: string;
+	userUri?: string;
+	teamUri?: string;
+	name?: string;
+	active?: boolean | string;
+	description?: string;
+	duration?: number | string;
+	durationOption?: Array<number | string>;
+	color?: string;
+	locale?: string;
+	locationKind?: string;
+	location?: string;
+	locationAdditionalInfo?: string;
+	locationPhoneNumber?: string;
+};
+
+export type CreateEventTypeLocationConfiguration = {
+	kind: CreateEventTypeLocationKind;
+	location?: string;
+	additional_info?: string;
+	phone_number?: string;
+};
+
+export type CreateEventTypeLocationKind =
+	| 'ask_invitee'
+	| 'custom'
+	| 'google_conference'
+	| 'gotomeeting_conference'
+	| 'inbound_call'
+	| 'microsoft_teams_conference'
+	| 'outbound_call'
+	| 'physical'
+	| 'webex_conference'
+	| 'zoom_conference';
+
+export type CreateEventTypeLocale = 'de' | 'en' | 'es' | 'fr' | 'it' | 'nl' | 'pt' | 'uk';
+
+export type CreateEventTypeQuery = {
+	owner: string;
+	name: string;
+	active?: boolean;
+	description?: string;
+	duration?: number;
+	duration_options?: number[];
+	locations?: CreateEventTypeLocationConfiguration[];
+	color?: string;
+	locale?: CreateEventTypeLocale;
+};
+
+const HEX_COLOR_REGEX = /^#[a-f\d]{6}$/i;
+const COLOR_EXAMPLE = '#fff200';
+const DURATION_MIN = 1;
+const DURATION_MAX = 720;
+const MAX_DURATION_OPTIONS = 4;
+const USER_URI_PREFIX = 'https://api.calendly.com/users/';
+const TEAM_URI_PREFIX = 'https://api.calendly.com/teams/';
+
+const LOCATION_KINDS: CreateEventTypeLocationKind[] = [
+	'ask_invitee',
+	'custom',
+	'google_conference',
+	'gotomeeting_conference',
+	'inbound_call',
+	'microsoft_teams_conference',
+	'outbound_call',
+	'physical',
+	'webex_conference',
+	'zoom_conference',
+];
+
+const LOCALES: CreateEventTypeLocale[] = ['de', 'en', 'es', 'fr', 'it', 'nl', 'pt', 'uk'];
+
+function toRecord(value: unknown): Record<string, unknown> {
+	return value && typeof value === 'object' ? { ...(value as Record<string, unknown>) } : {};
+}
+
+function normalizeRequiredString(value: unknown, fieldName: string, requiredMessage: string): string {
+	if (value === undefined || value === null) {
+		throw new Error(requiredMessage);
+	}
+	if (typeof value !== 'string') {
+		throw new Error(`${fieldName} must be a non-empty string`);
+	}
+	const trimmed = value.trim();
+	if (!trimmed) {
+		throw new Error(`${fieldName} must be a non-empty string`);
+	}
+	return trimmed;
+}
+
+function normalizeOptionalString(value: unknown, fieldName: string): string | undefined {
+	if (value === undefined || value === null) {
+		return undefined;
+	}
+	if (typeof value !== 'string') {
+		throw new Error(`${fieldName} must be a non-empty string`);
+	}
+	const trimmed = value.trim();
+	if (!trimmed) {
+		throw new Error(`${fieldName} must be a non-empty string`);
+	}
+	return trimmed;
+}
+
+function normalizeOptionalBoolean(value: unknown, fieldName: 'active'): boolean | undefined {
+	if (value === undefined || value === null) {
+		return undefined;
+	}
+	if (typeof value === 'boolean') {
+		return value;
+	}
+	if (typeof value !== 'string') {
+		throw new Error(`${fieldName} must be true or false`);
+	}
+	const normalized = value.trim().toLowerCase();
+	if (normalized === 'true') {
+		return true;
+	}
+	if (normalized === 'false') {
+		return false;
+	}
+	throw new Error(`${fieldName} must be true or false`);
+}
+
+function normalizeDurationValue(value: unknown, fieldName: 'duration' | 'duration_options'): number {
+	const numeric =
+		typeof value === 'number'
+			? value
+			: typeof value === 'string' && value.trim()
+				? Number(value)
+				: Number.NaN;
+
+	if (!Number.isFinite(numeric) || !Number.isInteger(numeric)) {
+		throw new Error(`${fieldName} must contain integers between ${DURATION_MIN} and ${DURATION_MAX}`);
+	}
+	if (numeric < DURATION_MIN || numeric > DURATION_MAX) {
+		throw new Error(`${fieldName} must contain integers between ${DURATION_MIN} and ${DURATION_MAX}`);
+	}
+	return numeric;
+}
+
+function normalizeOptionalDuration(value: unknown): number | undefined {
+	if (value === undefined || value === null) {
+		return undefined;
+	}
+	return normalizeDurationValue(value, 'duration');
+}
+
+function normalizeDurationOptions(value: unknown): number[] | undefined {
+	if (value === undefined || value === null) {
+		return undefined;
+	}
+	const values = Array.isArray(value) ? value : [value];
+	if (values.length === 0) {
+		return undefined;
+	}
+	if (values.length > MAX_DURATION_OPTIONS) {
+		throw new Error(`duration_options cannot include more than ${MAX_DURATION_OPTIONS} values`);
+	}
+
+	const normalized: number[] = [];
+	for (const entry of values) {
+		const numeric = normalizeDurationValue(entry, 'duration_options');
+		if (normalized.includes(numeric)) {
+			throw new Error('duration_options values must be unique');
+		}
+		normalized.push(numeric);
+	}
+
+	return normalized;
+}
+
+function normalizeColor(value: unknown): string | undefined {
+	const color = normalizeOptionalString(value, 'color');
+	if (!color) {
+		return undefined;
+	}
+	if (!HEX_COLOR_REGEX.test(color)) {
+		throw new Error(`color must be a hexadecimal color like ${COLOR_EXAMPLE}`);
+	}
+	return color.toLowerCase();
+}
+
+function normalizeLocale(value: unknown): CreateEventTypeLocale | undefined {
+	const locale = normalizeOptionalString(value, 'locale');
+	if (!locale) {
+		return undefined;
+	}
+	const normalized = locale.toLowerCase();
+	if (!LOCALES.includes(normalized as CreateEventTypeLocale)) {
+		throw new Error(`locale must be one of: ${LOCALES.join(', ')}`);
+	}
+	return normalized as CreateEventTypeLocale;
+}
+
+function normalizeLocationKind(value: unknown): CreateEventTypeLocationKind | undefined {
+	const kind = normalizeOptionalString(value, 'location_kind');
+	if (!kind) {
+		return undefined;
+	}
+	if (!LOCATION_KINDS.includes(kind as CreateEventTypeLocationKind)) {
+		throw new Error(`location_kind must be one of: ${LOCATION_KINDS.join(', ')}`);
+	}
+	return kind as CreateEventTypeLocationKind;
+}
+
+function normalizeOwnerUri(value: unknown, fieldName: 'owner' | 'user_uri' | 'team_uri'): string | undefined {
+	const owner = normalizeOptionalString(value, fieldName);
+	if (!owner) {
+		return undefined;
+	}
+	if (owner.startsWith(USER_URI_PREFIX) || owner.startsWith(TEAM_URI_PREFIX)) {
+		return owner;
+	}
+	throw new Error(`${fieldName} must be a Calendly user or team URI`);
+}
+
+function normalizeFlagLocation(
+	locationKindValue: unknown,
+	locationValue: unknown,
+	locationAdditionalInfoValue: unknown,
+	locationPhoneNumberValue: unknown
+): CreateEventTypeLocationConfiguration[] | undefined {
+	const kind = normalizeLocationKind(locationKindValue);
+	const location = normalizeOptionalString(locationValue, 'location');
+	const additionalInfo = normalizeOptionalString(locationAdditionalInfoValue, 'location_additional_info');
+	const phoneNumber = normalizeOptionalString(locationPhoneNumberValue, 'location_phone_number');
+
+	if (!kind) {
+		if (location || additionalInfo || phoneNumber) {
+			throw new Error('location_kind is required when providing location details');
+		}
+		return undefined;
+	}
+
+	return [
+		{
+			kind,
+			...(location ? { location } : {}),
+			...(additionalInfo ? { additional_info: additionalInfo } : {}),
+			...(phoneNumber ? { phone_number: phoneNumber } : {}),
+		},
+	];
+}
+
+function normalizeLocationRecord(value: unknown): CreateEventTypeLocationConfiguration {
+	const record = toRecord(value);
+	const kind = normalizeLocationKind(record.kind);
+	if (!kind) {
+		throw new Error('locations entries require a supported kind value');
+	}
+
+	const location = normalizeOptionalString(record.location, 'location');
+	const additionalInfo = normalizeOptionalString(record.additional_info ?? record.additionalInfo, 'additional_info');
+	const phoneNumber = normalizeOptionalString(record.phone_number ?? record.phoneNumber, 'phone_number');
+
+	return {
+		kind,
+		...(location ? { location } : {}),
+		...(additionalInfo ? { additional_info: additionalInfo } : {}),
+		...(phoneNumber ? { phone_number: phoneNumber } : {}),
+	};
+}
+
+function normalizeRawLocations(value: unknown): CreateEventTypeLocationConfiguration[] | undefined {
+	if (value === undefined || value === null) {
+		return undefined;
+	}
+	const values = Array.isArray(value) ? value : [value];
+	if (values.length === 0) {
+		return undefined;
+	}
+	return values.map((entry) => normalizeLocationRecord(entry));
+}
+
+function normalizeOwner(cmdOpts: CreateEventTypeCmdOptions, defaults: Record<string, unknown>): string {
+	const ownerFromRaw = normalizeOwnerUri(defaults.owner ?? defaults.owner_uri, 'owner');
+	const userUri = normalizeOwnerUri(cmdOpts.userUri ?? defaults.user_uri ?? defaults.user, 'user_uri');
+	const teamUri = normalizeOwnerUri(cmdOpts.teamUri ?? defaults.team_uri ?? defaults.team, 'team_uri');
+
+	const providedOwners = [ownerFromRaw, userUri, teamUri].filter((value): value is string => typeof value === 'string');
+	const uniqueOwners = [...new Set(providedOwners)];
+	if (uniqueOwners.length === 0) {
+		throw new Error(
+			'owner is required (use --user-uri, --team-uri, or --raw {"owner":"https://api.calendly.com/users/..."} )'
+		);
+	}
+	if (uniqueOwners.length > 1) {
+		throw new Error('provide exactly one owner source: owner, user_uri, or team_uri');
+	}
+	return uniqueOwners[0]!;
+}
+
+function extractResource(result: Record<string, unknown>): Record<string, unknown> | null {
+	if (result.resource && typeof result.resource === 'object') {
+		return toRecord(result.resource);
+	}
+	if (
+		typeof result.uri === 'string' ||
+		typeof result.scheduling_url === 'string' ||
+		typeof result.slug === 'string' ||
+		typeof result.name === 'string'
+	) {
+		return toRecord(result);
+	}
+	return null;
+}
+
+export function normalizeCreateEventTypeQuery(
+	cmdOpts: CreateEventTypeCmdOptions,
+	defaults: Record<string, unknown> = {}
+): CreateEventTypeQuery {
+	const owner = normalizeOwner(cmdOpts, defaults);
+	const name = normalizeRequiredString(
+		cmdOpts.name ?? defaults.name,
+		'name',
+		'name is required (use --name or --raw {"name":"..."} )'
+	);
+	const active = normalizeOptionalBoolean(cmdOpts.active ?? defaults.active, 'active');
+	const description = normalizeOptionalString(cmdOpts.description ?? defaults.description, 'description');
+	const duration = normalizeOptionalDuration(cmdOpts.duration ?? defaults.duration);
+	const durationOptions =
+		Array.isArray(cmdOpts.durationOption) && cmdOpts.durationOption.length > 0
+			? normalizeDurationOptions(cmdOpts.durationOption)
+			: normalizeDurationOptions(defaults.duration_options ?? defaults.durationOptions);
+	const color = normalizeColor(cmdOpts.color ?? defaults.color);
+	const locale = normalizeLocale(cmdOpts.locale ?? defaults.locale);
+	const locations =
+		normalizeFlagLocation(
+			cmdOpts.locationKind ?? defaults.location_kind ?? defaults.locationKind,
+			cmdOpts.location ?? defaults.location,
+			cmdOpts.locationAdditionalInfo ?? defaults.location_additional_info ?? defaults.locationAdditionalInfo,
+			cmdOpts.locationPhoneNumber ?? defaults.location_phone_number ?? defaults.locationPhoneNumber
+		) ?? normalizeRawLocations(defaults.locations);
+
+	if (duration === undefined && durationOptions === undefined) {
+		throw new Error(
+			'provide duration or duration_options (use --duration, repeated --duration-option, or --raw {"duration":15} / {"duration_options":[15,30]})'
+		);
+	}
+
+	if (duration !== undefined && durationOptions && !durationOptions.includes(duration)) {
+		throw new Error('duration must be one of the provided duration_options values');
+	}
+
+	return {
+		owner,
+		name,
+		...(active !== undefined ? { active } : {}),
+		...(description ? { description } : {}),
+		...(duration !== undefined ? { duration } : {}),
+		...(durationOptions ? { duration_options: durationOptions } : {}),
+		...(locations ? { locations } : {}),
+		...(color ? { color } : {}),
+		...(locale ? { locale } : {}),
+	};
+}
+
+export function toCreateEventTypeMcpArgs(query: CreateEventTypeQuery): Record<string, unknown> {
+	return { ...query };
+}
+
+export function toCreateEventTypeRestBody(query: CreateEventTypeQuery): Record<string, unknown> {
+	return { ...query };
+}
+
+export function shapeCreateEventTypeResult(
+	result: unknown,
+	query: CreateEventTypeQuery
+): Record<string, unknown> {
+	const response = toRecord(result);
+	const resource = extractResource(response);
+	return {
+		query: { ...query },
+		meta: {
+			created: Boolean(resource),
+		},
+		resource,
+	};
+}
+
+export function toSafeCreateEventTypeError(error: unknown): string {
+	const message = error instanceof Error ? error.message : String(error);
+	if (
+		message.includes('owner is required') ||
+		message.includes('provide exactly one owner source') ||
+		message.includes('name is required') ||
+		message.includes('must be a non-empty string') ||
+		message.includes('must be true or false') ||
+		message.includes('provide duration or duration_options') ||
+		message.includes('duration must be one of the provided duration_options values') ||
+		message.includes('duration_options cannot include more than') ||
+		message.includes('duration_options values must be unique') ||
+		message.includes('duration must contain integers between') ||
+		message.includes('duration_options must contain integers between') ||
+		message.includes('color must be a hexadecimal color') ||
+		message.includes('locale must be one of') ||
+			message.includes('location_kind must be one of') ||
+			message.includes('location_kind is required when providing location details') ||
+			message.includes('locations entries require a supported kind value') ||
+			message.includes('must be a Calendly user or team URI')
+	) {
+		return message;
+	}
+	if (message.includes('kind: "solo"') || message.includes('only supports one-on-one event types') || message.includes('non solo')) {
+		return 'Calendly only allows creating solo event types through this endpoint.';
+	}
+	if (message.includes('Insufficient scope') || message.includes('required_scopes') || message.includes('event_types:write')) {
+		return 'Your token is missing the event_types:write scope required to create event types.';
+	}
+	if (/\b401\b/.test(message)) {
+		return 'Unable to authenticate with Calendly. Verify CALENDLY_API_KEY.';
+	}
+	if (/\b403\b/.test(message)) {
+		return 'You do not have permission to create this event type. Verify token scope and owner access.';
+	}
+	if (/\b404\b/.test(message)) {
+		return 'owner was not found. Verify --user-uri, --team-uri, or raw owner URI.';
+	}
+	return 'Unable to create event type. Verify owner, requested fields, and token scope.';
+}

--- a/src/create-event-type.ts
+++ b/src/create-event-type.ts
@@ -210,10 +210,23 @@ function normalizeOwnerUri(value: unknown, fieldName: 'owner' | 'user_uri' | 'te
 	if (!owner) {
 		return undefined;
 	}
-	if (owner.startsWith(USER_URI_PREFIX) || owner.startsWith(TEAM_URI_PREFIX)) {
-		return owner;
+	switch (fieldName) {
+		case 'owner':
+			if (owner.startsWith(USER_URI_PREFIX) || owner.startsWith(TEAM_URI_PREFIX)) {
+				return owner;
+			}
+			throw new Error('owner must be a Calendly user or team URI');
+		case 'user_uri':
+			if (owner.startsWith(USER_URI_PREFIX)) {
+				return owner;
+			}
+			throw new Error('user_uri must be a Calendly user URI');
+		case 'team_uri':
+			if (owner.startsWith(TEAM_URI_PREFIX)) {
+				return owner;
+			}
+			throw new Error('team_uri must be a Calendly team URI');
 	}
-	throw new Error(`${fieldName} must be a Calendly user or team URI`);
 }
 
 function normalizeFlagLocation(
@@ -399,7 +412,9 @@ export function toSafeCreateEventTypeError(error: unknown): string {
 			message.includes('location_kind must be one of') ||
 			message.includes('location_kind is required when providing location details') ||
 			message.includes('locations entries require a supported kind value') ||
-			message.includes('must be a Calendly user or team URI')
+			message.includes('owner must be a Calendly user or team URI') ||
+			message.includes('user_uri must be a Calendly user URI') ||
+			message.includes('team_uri must be a Calendly team URI')
 	) {
 		return message;
 	}


### PR DESCRIPTION
## Summary
- add a handwritten `create-event-type` command with MCP-first execution and REST fallback
- normalize and validate documented create payload fields, including user/team owner handling
- document the command in README and handwritten CLI help

Closes #29

## Risk
- mutates Calendly event type configuration, so live smoke validation should use a disposable inactive event type
- undocumented issue-body flags like `slug`, `secret`, and buffer settings remain intentionally unsupported

## How Verified
- `bun test`
- `bunx tsc --noEmit`
- `./calendly --help`
- `./calendly create-event-type --help`
- attempted `codex review --base main`; the first run surfaced an owner contract mismatch that was fixed before final verification

## Notes
- live API smoke validation was not possible in this environment because `CALENDLY_API_KEY` is not set