### PR TITLE
chore: update bun.lock after dependency install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ Thumbs.db
 # Local review tooling
 compound-engineering.local.md
 .context/compound-engineering/feature-video/
+.ai/
+.worktrees/

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "calendly-cli-openclaw-skill",


### PR DESCRIPTION
## What

Update `bun.lock` after running `bun install` to ensure dependencies are locked and installable in the AlphaClaw container.

## Why

The Calendly skill runs via `#!/usr/bin/env bun` and imports `commander`, `axios`, and `mcporter`. The AlphaClaw skill sync script excludes `node_modules`, so the installed skill at `/data/.openclaw/skills/calendly/` was missing its dependencies, causing:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'commander' imported from
/data/.openclaw/skills/calendly/src/commands/program.ts
```

With the updated `bun.lock`, the container can run `bun install` in the skill directory after sync to materialize dependencies.

Also adds `.ai/` and `.worktrees/` to `.gitignore` (generated by local tooling).

## Tests

```bash
cd /home/art/projects/skills/work/calendly && bun install
./calendly --help  # should print usage
```

Verified working inside AlphaClaw container after `docker cp node_modules`:
```
calendly — calendly-mcp-server
Usage: calendly <command> [options]
```